### PR TITLE
fix: turbo daemon hang in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,4 +23,8 @@ jobs:
           bun-version: latest
       - run: bun install --frozen-lockfile
       - run: bun run check
-      - run: bun test
+      - name: Test
+        run: bun test
+        timeout-minutes: 5
+        env:
+          TURBO_NO_DAEMON: '1'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,11 @@ jobs:
           bun-version: latest
       - run: bun install --frozen-lockfile
       - run: bun run check
-      - run: bun test
+      - name: Test
+        run: bun test
+        timeout-minutes: 5
+        env:
+          TURBO_NO_DAEMON: '1'
 
   build-and-push:
     needs: [test]


### PR DESCRIPTION
Turbo daemon hangs on GH runners. Add TURBO_NO_DAEMON=1 and 5-min step timeout for test steps.