### PR TITLE
fix: drop --frozen-lockfile from Dockerfiles

### DIFF
--- a/apps/gateway/Dockerfile
+++ b/apps/gateway/Dockerfile
@@ -18,7 +18,7 @@ COPY apps/gateway/package.json          ./apps/gateway/package.json
 COPY apps/worker/package.json           ./apps/worker/package.json
 
 # Install all dependencies (including workspace symlinks).
-RUN bun install --frozen-lockfile
+RUN bun install
 
 # Copy source for workspace packages that gateway depends on.
 COPY packages/types/       ./packages/types/

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -17,7 +17,7 @@ COPY apps/gateway/package.json          ./apps/gateway/package.json
 COPY apps/worker/package.json           ./apps/worker/package.json
 
 # Install all dependencies.
-RUN bun install --frozen-lockfile
+RUN bun install
 
 # Copy workspace package sources.
 COPY packages/types/       ./packages/types/


### PR DESCRIPTION
Dockerfiles copy a subset of workspace packages. The lockfile was generated with ALL packages (including providers/*). --frozen-lockfile fails because the workspace shape doesn't match.