### PR TITLE
fix: add snapshot-store to Dockerfiles + gotchas in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,16 @@ See @docs/testing.md for full strategy.
 - Commit prefix with scope: `firecracker: add snapshot restore`, `gateway: add sessions`
 - Each commit independently valid (bisect-friendly)
 
+## Gotchas
+
+- **Dockerfiles must list ALL workspace packages.** When adding a new `packages/*` directory,
+  update BOTH `apps/gateway/Dockerfile` AND `apps/worker/Dockerfile` with: the package.json
+  COPY (manifest stage), the source COPY (builder stage), and the runner COPY (final stage).
+  Missing a package causes `bun install` to fail in CI with "Workspace dependency not found."
+- **Turbo daemon hangs on GH runners.** Always set `TURBO_NO_DAEMON=1` in CI workflows.
+- **Vitest polyfill rejects `new Response('', {status: 204})`.** Use `new Response(null, {status: 204})`
+  in test mocks for HTTP 204 responses.
+
 ## Current Phase
 
 v0.1 — single server, no K8s. See @docs/roadmap.md

--- a/apps/gateway/Dockerfile
+++ b/apps/gateway/Dockerfile
@@ -13,8 +13,9 @@ COPY package.json bun.lock* ./
 COPY packages/types/package.json        ./packages/types/package.json
 COPY packages/firecracker/package.json  ./packages/firecracker/package.json
 COPY packages/proxy/package.json        ./packages/proxy/package.json
-COPY packages/scheduler/package.json    ./packages/scheduler/package.json
-COPY apps/gateway/package.json          ./apps/gateway/package.json
+COPY packages/scheduler/package.json      ./packages/scheduler/package.json
+COPY packages/snapshot-store/package.json ./packages/snapshot-store/package.json
+COPY apps/gateway/package.json            ./apps/gateway/package.json
 COPY apps/worker/package.json           ./apps/worker/package.json
 
 # Install all dependencies (including workspace symlinks).
@@ -24,7 +25,8 @@ RUN bun install
 COPY packages/types/       ./packages/types/
 COPY packages/firecracker/ ./packages/firecracker/
 COPY packages/proxy/       ./packages/proxy/
-COPY packages/scheduler/   ./packages/scheduler/
+COPY packages/scheduler/       ./packages/scheduler/
+COPY packages/snapshot-store/  ./packages/snapshot-store/
 
 # Copy gateway source.
 COPY apps/gateway/ ./apps/gateway/
@@ -53,7 +55,8 @@ COPY --from=builder /build/node_modules ./node_modules
 COPY --from=builder /build/packages/types/       ./packages/types/
 COPY --from=builder /build/packages/firecracker/ ./packages/firecracker/
 COPY --from=builder /build/packages/proxy/       ./packages/proxy/
-COPY --from=builder /build/packages/scheduler/   ./packages/scheduler/
+COPY --from=builder /build/packages/scheduler/       ./packages/scheduler/
+COPY --from=builder /build/packages/snapshot-store/  ./packages/snapshot-store/
 
 # Copy gateway source (we run from source with bun, not from the dist bundle,
 # because bun handles TypeScript natively and the workspace imports resolve

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -13,6 +13,7 @@ COPY packages/types/package.json        ./packages/types/package.json
 COPY packages/firecracker/package.json  ./packages/firecracker/package.json
 COPY packages/proxy/package.json        ./packages/proxy/package.json
 COPY packages/scheduler/package.json    ./packages/scheduler/package.json
+COPY packages/snapshot-store/package.json ./packages/snapshot-store/package.json
 COPY apps/gateway/package.json          ./apps/gateway/package.json
 COPY apps/worker/package.json           ./apps/worker/package.json
 
@@ -23,7 +24,8 @@ RUN bun install
 COPY packages/types/       ./packages/types/
 COPY packages/firecracker/ ./packages/firecracker/
 COPY packages/proxy/       ./packages/proxy/
-COPY packages/scheduler/   ./packages/scheduler/
+COPY packages/scheduler/       ./packages/scheduler/
+COPY packages/snapshot-store/  ./packages/snapshot-store/
 
 # Copy worker source.
 COPY apps/worker/ ./apps/worker/
@@ -63,7 +65,8 @@ COPY --from=builder /build/node_modules ./node_modules
 COPY --from=builder /build/packages/types/       ./packages/types/
 COPY --from=builder /build/packages/firecracker/ ./packages/firecracker/
 COPY --from=builder /build/packages/proxy/       ./packages/proxy/
-COPY --from=builder /build/packages/scheduler/   ./packages/scheduler/
+COPY --from=builder /build/packages/scheduler/       ./packages/scheduler/
+COPY --from=builder /build/packages/snapshot-store/  ./packages/snapshot-store/
 COPY --from=builder /build/apps/worker/ ./apps/worker/
 
 # Create directories that the worker uses at runtime.


### PR DESCRIPTION
Dockerfiles were missing packages/snapshot-store. Added gotchas section to CLAUDE.md documenting this pattern so it doesn't happen every time we add a new package.