### PR TITLE
feat: GitHub App integration — @paws commands in PR comments

### DIFF
--- a/apps/control-plane/package.json
+++ b/apps/control-plane/package.json
@@ -21,6 +21,7 @@
     "@hono/oidc-auth": "^1.8.1",
     "@hono/zod-openapi": "1.2.3",
     "@paws/credentials": "workspace:*",
+    "@paws/integrations": "workspace:*",
     "@paws/provider-aws-ec2": "workspace:*",
     "@paws/provider-hetzner-cloud": "workspace:*",
     "@paws/providers": "workspace:*",

--- a/apps/control-plane/src/app.ts
+++ b/apps/control-plane/src/app.ts
@@ -2,6 +2,14 @@ import { randomUUID } from 'node:crypto';
 
 import { OpenAPIHono } from '@hono/zod-openapi';
 import type { Hono } from 'hono';
+import {
+  verifyWebhookSignature,
+  parseWebhookEvent,
+  matchDaemon,
+  createGitHubAuth,
+  postComment,
+} from '@paws/integrations';
+import type { GitHubDaemon } from '@paws/integrations';
 import { selectWorker } from '@paws/scheduler';
 
 import type { WorkerRegistry } from './discovery/registry.js';
@@ -506,6 +514,135 @@ export async function createControlPlaneApp(deps: ControlPlaneDeps) {
 
     return c.json({ accepted: true as const, sessionId }, 202);
   });
+
+  // --- GitHub App webhooks (no auth — validated by HMAC signature) ---
+
+  const githubWebhookSecret = process.env['GITHUB_WEBHOOK_SECRET'];
+  const githubAppId = process.env['GITHUB_APP_ID'];
+  const githubPrivateKey = process.env['GITHUB_APP_PRIVATE_KEY'];
+
+  if (githubWebhookSecret && githubAppId && githubPrivateKey) {
+    const githubAuth = createGitHubAuth(githubAppId, githubPrivateKey);
+
+    app.post('/webhooks/github', async (c) => {
+      // Verify HMAC signature
+      const signature = c.req.header('x-hub-signature-256');
+      const rawBody = await c.req.text();
+      if (!signature || !verifyWebhookSignature(rawBody, signature, githubWebhookSecret)) {
+        return c.json({ error: { code: 'UNAUTHORIZED', message: 'Invalid signature' } }, 401);
+      }
+
+      const payload = JSON.parse(rawBody) as Record<string, unknown>;
+      const event = parseWebhookEvent(payload);
+      if (!event) {
+        // Not a @paws mention, ignore silently
+        return c.json({ ignored: true }, 200);
+      }
+
+      // Find matching daemon
+      const githubDaemons = daemonStore
+        .list()
+        .filter((d): d is GitHubDaemon & typeof d => d.trigger.type === 'github') as GitHubDaemon[];
+      const match = matchDaemon(event, githubDaemons);
+
+      if (!match) {
+        // Post a helpful comment
+        await postComment(
+          { auth: githubAuth },
+          event.installationId,
+          event.issueUrl,
+          `No daemon configured for \`@paws ${event.command}\` in this repo.`,
+        ).catch(() => {}); // best-effort
+        return c.json({ error: { code: 'NO_MATCH', message: 'No daemon matches' } }, 200);
+      }
+
+      const { daemon } = match;
+
+      // Check governance (daemon from store has proper governance type)
+      const fullDaemon = daemonStore.get(daemon.role);
+      if (fullDaemon && !governance.checkRateLimit(daemon.role, fullDaemon.governance)) {
+        await postComment(
+          { auth: githubAuth },
+          event.installationId,
+          event.issueUrl,
+          `Rate limit exceeded for \`@paws ${event.command}\`. Try again later.`,
+        ).catch(() => {});
+        return c.json({ error: { code: 'RATE_LIMITED', message: 'Rate limited' } }, 429);
+      }
+
+      // Acknowledge quickly
+      await postComment(
+        { auth: githubAuth },
+        event.installationId,
+        event.issueUrl,
+        `Running \`${event.command}\`... I'll post results when done.`,
+      ).catch(() => {});
+
+      // Create session with GitHub metadata
+      const sessionId = randomUUID();
+      // Build session request from daemon config (use fullDaemon for proper types)
+      const src = fullDaemon ?? daemon;
+      const sessionRequest = {
+        snapshot: src.snapshot,
+        workload: {
+          type: 'script' as const,
+          script: src.workload.script,
+          env: {
+            ...src.workload.env,
+            TRIGGER_PAYLOAD: JSON.stringify(event),
+            GITHUB_REPO: event.repo,
+            GITHUB_COMMAND: event.command,
+            ...(event.prNumber ? { GITHUB_PR_NUMBER: String(event.prNumber) } : {}),
+          },
+        },
+        resources: src.resources,
+        timeoutMs: 600_000,
+        network: fullDaemon?.network,
+        metadata: {
+          triggerType: 'github',
+          repo: event.repo,
+          command: event.command,
+          prNumber: event.prNumber ? String(event.prNumber) : '',
+          issueUrl: event.issueUrl,
+          installationId: String(event.installationId),
+          sender: event.sender,
+        },
+      };
+
+      sessionStore.create(sessionId, sessionRequest, daemon.role);
+      governance.recordAction(daemon.role);
+      daemonStore.recordInvocation(daemon.role);
+
+      // Dispatch to worker
+      dispatchSession(discovery, legacyWorkerClient, sessionStore, sessionId, sessionRequest);
+
+      // Listen for completion to post results back
+      const resultListener = (
+        updatedId: string,
+        session: import('./store/sessions.js').StoredSession,
+      ) => {
+        if (updatedId !== sessionId) return;
+        const terminal = ['completed', 'failed', 'timeout', 'cancelled'];
+        if (!terminal.includes(session.status)) return;
+
+        sessionEvents.off('update', resultListener);
+
+        const resultBody =
+          session.status === 'completed'
+            ? ((session.output as string) ?? session.stdout ?? 'Agent completed with no output.')
+            : `Agent ${session.status}: ${session.stderr ?? 'Unknown error'}`;
+
+        postComment({ auth: githubAuth }, event.installationId, event.issueUrl, resultBody).catch(
+          (err) => {
+            console.error(`[github] Failed to post result for session ${sessionId}:`, err);
+          },
+        );
+      };
+      sessionEvents.on('update', resultListener);
+
+      return c.json({ accepted: true, sessionId }, 202);
+    });
+  }
 
   // --- Fleet ---
 

--- a/apps/dashboard/src/components/Layout.tsx
+++ b/apps/dashboard/src/components/Layout.tsx
@@ -1,10 +1,6 @@
 import { useState } from 'react';
 import { NavLink, Outlet } from 'react-router';
 
-const CAT_LOGO = ` /\\_/\\
-( o.o )
- > ^ <`;
-
 function SidebarLink({ to, label, onClick }: { to: string; label: string; onClick?: () => void }) {
   return (
     <NavLink

--- a/apps/dashboard/src/components/StatusBadge.tsx
+++ b/apps/dashboard/src/components/StatusBadge.tsx
@@ -1,4 +1,7 @@
 type Status =
+  | 'active'
+  | 'paused'
+  | 'stopped'
   | 'pending'
   | 'running'
   | 'completed'

--- a/apps/dashboard/src/pages/Daemons.tsx
+++ b/apps/dashboard/src/pages/Daemons.tsx
@@ -73,7 +73,7 @@ export function Daemons() {
         </div>
       ) : daemons.data && daemons.data.daemons.length > 0 ? (
         <div className="space-y-3">
-          {daemons.data.daemons.map((d: Daemon) => (
+          {(daemons.data.daemons as Daemon[]).map((d) => (
             <div key={d.role} className="bg-zinc-900 border border-zinc-800 rounded-lg p-4">
               <div className="flex items-center justify-between mb-2">
                 <div className="flex items-center gap-3">

--- a/bun.lock
+++ b/bun.lock
@@ -20,6 +20,7 @@
         "@hono/oidc-auth": "^1.8.1",
         "@hono/zod-openapi": "1.2.3",
         "@paws/credentials": "workspace:*",
+        "@paws/integrations": "workspace:*",
         "@paws/provider-aws-ec2": "workspace:*",
         "@paws/provider-hetzner-cloud": "workspace:*",
         "@paws/providers": "workspace:*",
@@ -100,6 +101,19 @@
       "dependencies": {
         "@paws/types": "workspace:*",
         "neverthrow": "^8.2.0",
+      },
+      "devDependencies": {
+        "bun-types": "^1.3.11",
+        "vitest": "^4.1.2",
+      },
+    },
+    "packages/integrations": {
+      "name": "@paws/integrations",
+      "version": "0.1.0",
+      "dependencies": {
+        "@octokit/rest": "^22.0.0",
+        "jose": "^6.0.11",
+        "zod": "^3.25.7",
       },
       "devDependencies": {
         "bun-types": "^1.3.11",
@@ -433,6 +447,30 @@
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
+    "@octokit/auth-token": ["@octokit/auth-token@6.0.0", "", {}, "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w=="],
+
+    "@octokit/core": ["@octokit/core@7.0.6", "", { "dependencies": { "@octokit/auth-token": "^6.0.0", "@octokit/graphql": "^9.0.3", "@octokit/request": "^10.0.6", "@octokit/request-error": "^7.0.2", "@octokit/types": "^16.0.0", "before-after-hook": "^4.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q=="],
+
+    "@octokit/endpoint": ["@octokit/endpoint@11.0.3", "", { "dependencies": { "@octokit/types": "^16.0.0", "universal-user-agent": "^7.0.2" } }, "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag=="],
+
+    "@octokit/graphql": ["@octokit/graphql@9.0.3", "", { "dependencies": { "@octokit/request": "^10.0.6", "@octokit/types": "^16.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA=="],
+
+    "@octokit/openapi-types": ["@octokit/openapi-types@27.0.0", "", {}, "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA=="],
+
+    "@octokit/plugin-paginate-rest": ["@octokit/plugin-paginate-rest@14.0.0", "", { "dependencies": { "@octokit/types": "^16.0.0" }, "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw=="],
+
+    "@octokit/plugin-request-log": ["@octokit/plugin-request-log@6.0.0", "", { "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q=="],
+
+    "@octokit/plugin-rest-endpoint-methods": ["@octokit/plugin-rest-endpoint-methods@17.0.0", "", { "dependencies": { "@octokit/types": "^16.0.0" }, "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw=="],
+
+    "@octokit/request": ["@octokit/request@10.0.8", "", { "dependencies": { "@octokit/endpoint": "^11.0.3", "@octokit/request-error": "^7.0.2", "@octokit/types": "^16.0.0", "fast-content-type-parse": "^3.0.0", "json-with-bigint": "^3.5.3", "universal-user-agent": "^7.0.2" } }, "sha512-SJZNwY9pur9Agf7l87ywFi14W+Hd9Jg6Ifivsd33+/bGUQIjNujdFiXII2/qSlN2ybqUHfp5xpekMEjIBTjlSw=="],
+
+    "@octokit/request-error": ["@octokit/request-error@7.1.0", "", { "dependencies": { "@octokit/types": "^16.0.0" } }, "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw=="],
+
+    "@octokit/rest": ["@octokit/rest@22.0.1", "", { "dependencies": { "@octokit/core": "^7.0.6", "@octokit/plugin-paginate-rest": "^14.0.0", "@octokit/plugin-request-log": "^6.0.0", "@octokit/plugin-rest-endpoint-methods": "^17.0.0" } }, "sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw=="],
+
+    "@octokit/types": ["@octokit/types@16.0.0", "", { "dependencies": { "@octokit/openapi-types": "^27.0.0" } }, "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg=="],
+
     "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 
     "@oxc-parser/binding-android-arm-eabi": ["@oxc-parser/binding-android-arm-eabi@0.120.0", "", { "os": "android", "cpu": "arm" }, "sha512-WU3qtINx802wOl8RxAF1v0VvmC2O4D9M8Sv486nLeQ7iPHVmncYZrtBhB4SYyX+XZxj2PNnCcN+PW21jHgiOxg=="],
@@ -602,6 +640,8 @@
     "@paws/dashboard": ["@paws/dashboard@workspace:apps/dashboard"],
 
     "@paws/firecracker": ["@paws/firecracker@workspace:packages/firecracker"],
+
+    "@paws/integrations": ["@paws/integrations@workspace:packages/integrations"],
 
     "@paws/provider-aws-ec2": ["@paws/provider-aws-ec2@workspace:providers/aws-ec2"],
 
@@ -873,6 +913,8 @@
 
     "bcrypt-pbkdf": ["bcrypt-pbkdf@1.0.2", "", { "dependencies": { "tweetnacl": "^0.14.3" } }, "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w=="],
 
+    "before-after-hook": ["before-after-hook@4.0.0", "", {}, "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ=="],
+
     "bintrees": ["bintrees@1.0.2", "", {}, "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw=="],
 
     "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
@@ -919,6 +961,8 @@
 
     "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
 
+    "fast-content-type-parse": ["fast-content-type-parse@3.0.0", "", {}, "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg=="],
+
     "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
 
     "fast-xml-builder": ["fast-xml-builder@1.1.4", "", { "dependencies": { "path-expression-matcher": "^1.1.3" } }, "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg=="],
@@ -959,9 +1003,13 @@
 
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
+    "jose": ["jose@6.2.2", "", {}, "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="],
+
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
+
+    "json-with-bigint": ["json-with-bigint@3.5.8", "", {}, "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw=="],
 
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
@@ -1134,6 +1182,8 @@
     "unbash": ["unbash@2.2.0", "", {}, "sha512-X2wH19RAPZE3+ldGicOkoj/SIA83OIxcJ6Cuaw23hf8Xc6fQpvZXY0SftE2JgS0QhYLUG4uwodSI3R53keyh7w=="],
 
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
+    "universal-user-agent": ["universal-user-agent@7.0.3", "", {}, "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A=="],
 
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
 

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@paws/integrations",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@octokit/rest": "^22.0.0",
+    "jose": "^6.0.11",
+    "zod": "^3.25.7"
+  },
+  "devDependencies": {
+    "bun-types": "^1.3.11",
+    "vitest": "^4.1.2"
+  }
+}

--- a/packages/integrations/src/callback.test.ts
+++ b/packages/integrations/src/callback.test.ts
@@ -1,0 +1,120 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { postComment } from './callback.js';
+import type { CallbackDeps } from './callback.js';
+
+const mockAuth = {
+  getInstallationToken: vi.fn().mockResolvedValue('ghs_test_token'),
+};
+
+const deps: CallbackDeps = { auth: mockAuth };
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.restoreAllMocks();
+  mockAuth.getInstallationToken = vi.fn().mockResolvedValue('ghs_test_token');
+  vi.stubGlobal('fetch', vi.fn());
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('postComment', () => {
+  test('posts comment successfully', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 201,
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    await postComment(
+      deps,
+      12345,
+      'https://api.github.com/repos/org/repo/issues/42',
+      'Session completed successfully.',
+    );
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://api.github.com/repos/org/repo/issues/42/comments',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer ghs_test_token',
+        }),
+        body: JSON.stringify({ body: 'Session completed successfully.' }),
+      }),
+    );
+  });
+
+  test('retries on 429 rate limit', async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 429,
+        text: async () => 'rate limited',
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+      });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const promise = postComment(
+      deps,
+      12345,
+      'https://api.github.com/repos/org/repo/issues/42',
+      'result',
+    );
+
+    // Advance past the retry delay (attempt 0: 2000ms)
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    await promise;
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  test('throws on non-retryable error (404)', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      text: async () => 'not found',
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    await expect(
+      postComment(deps, 12345, 'https://api.github.com/repos/org/repo/issues/42', 'result'),
+    ).rejects.toThrow('GitHub comment post failed: 404 not found');
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+  });
+
+  test('gives up after 3 retries', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      text: async () => 'rate limited',
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const promise = postComment(
+      deps,
+      12345,
+      'https://api.github.com/repos/org/repo/issues/42',
+      'result',
+    );
+
+    // Attach rejection handler immediately to prevent unhandled rejection
+    const result = promise.catch((e: Error) => e);
+
+    // Advance past all retry delays: 2000 + 4000 + 6000 = 12000ms
+    await vi.advanceTimersByTimeAsync(20_000);
+
+    const error = await result;
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain('GitHub API 429');
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+});

--- a/packages/integrations/src/callback.ts
+++ b/packages/integrations/src/callback.ts
@@ -1,0 +1,42 @@
+import type { GitHubAuth } from './github-auth.js';
+
+export interface CallbackDeps {
+  auth: GitHubAuth;
+}
+
+/** Post a comment on a GitHub issue/PR */
+export async function postComment(
+  deps: CallbackDeps,
+  installationId: number,
+  issueUrl: string,
+  body: string,
+): Promise<void> {
+  const token = await deps.auth.getInstallationToken(installationId);
+  const commentsUrl = `${issueUrl}/comments`;
+
+  let lastError: Error | null = null;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const res = await fetch(commentsUrl, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/vnd.github+json',
+        'Content-Type': 'application/json',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+      body: JSON.stringify({ body }),
+    });
+
+    if (res.ok) return;
+
+    if (res.status === 403 || res.status === 429) {
+      lastError = new Error(`GitHub API ${res.status}: ${await res.text()}`);
+      await new Promise((r) => setTimeout(r, (attempt + 1) * 2000));
+      continue;
+    }
+
+    throw new Error(`GitHub comment post failed: ${res.status} ${await res.text()}`);
+  }
+
+  throw lastError ?? new Error('Failed to post comment after retries');
+}

--- a/packages/integrations/src/github-auth.ts
+++ b/packages/integrations/src/github-auth.ts
@@ -1,0 +1,60 @@
+import { SignJWT, importPKCS8 } from 'jose';
+
+interface CachedToken {
+  token: string;
+  expiresAt: Date;
+  installationId: number;
+}
+
+export interface GitHubAuth {
+  getInstallationToken(installationId: number): Promise<string>;
+}
+
+export function createGitHubAuth(appId: string, privateKeyPem: string): GitHubAuth {
+  const tokenCache = new Map<number, CachedToken>();
+
+  async function createAppJwt(): Promise<string> {
+    const key = await importPKCS8(privateKeyPem, 'RS256');
+    return new SignJWT({})
+      .setProtectedHeader({ alg: 'RS256' })
+      .setIssuer(appId)
+      .setIssuedAt()
+      .setExpirationTime('10m')
+      .sign(key);
+  }
+
+  return {
+    async getInstallationToken(installationId) {
+      const cached = tokenCache.get(installationId);
+      if (cached && cached.expiresAt > new Date(Date.now() + 5 * 60_000)) {
+        return cached.token;
+      }
+
+      const jwt = await createAppJwt();
+      const res = await fetch(
+        `https://api.github.com/app/installations/${installationId}/access_tokens`,
+        {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${jwt}`,
+            Accept: 'application/vnd.github+json',
+            'X-GitHub-Api-Version': '2022-11-28',
+          },
+        },
+      );
+
+      if (!res.ok) {
+        throw new Error(`GitHub token exchange failed: ${res.status} ${await res.text()}`);
+      }
+
+      const data = (await res.json()) as { token: string; expires_at: string };
+      tokenCache.set(installationId, {
+        token: data.token,
+        expiresAt: new Date(data.expires_at),
+        installationId,
+      });
+
+      return data.token;
+    },
+  };
+}

--- a/packages/integrations/src/github.test.ts
+++ b/packages/integrations/src/github.test.ts
@@ -1,0 +1,109 @@
+import { describe, test, expect } from 'vitest';
+import { createHmac } from 'node:crypto';
+import { verifyWebhookSignature, parsePawsMention, parseWebhookEvent } from './github.js';
+
+const SECRET = 'test-webhook-secret';
+
+function sign(payload: string): string {
+  return 'sha256=' + createHmac('sha256', SECRET).update(payload).digest('hex');
+}
+
+function makeWebhookPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    action: 'created',
+    comment: {
+      body: '@paws review this PR',
+      url: 'https://api.github.com/repos/org/repo/issues/comments/1',
+    },
+    issue: {
+      number: 42,
+      pull_request: { url: 'https://api.github.com/repos/org/repo/pulls/42' },
+      url: 'https://api.github.com/repos/org/repo/issues/42',
+    },
+    repository: { full_name: 'org/repo' },
+    sender: { login: 'alice' },
+    installation: { id: 12345 },
+    ...overrides,
+  };
+}
+
+describe('verifyWebhookSignature', () => {
+  test('valid signature returns true', () => {
+    const payload = '{"test": true}';
+    const sig = sign(payload);
+    expect(verifyWebhookSignature(payload, sig, SECRET)).toBe(true);
+  });
+
+  test('invalid signature returns false', () => {
+    const payload = '{"test": true}';
+    const sig = sign('different payload');
+    expect(verifyWebhookSignature(payload, sig, SECRET)).toBe(false);
+  });
+
+  test('wrong length signature returns false', () => {
+    const payload = '{"test": true}';
+    expect(verifyWebhookSignature(payload, 'sha256=short', SECRET)).toBe(false);
+  });
+});
+
+describe('parsePawsMention', () => {
+  test('extracts command from "@paws review this PR"', () => {
+    expect(parsePawsMention('@paws review this PR')).toBe('review this PR');
+  });
+
+  test('extracts command case-insensitively', () => {
+    expect(parsePawsMention('@PAWS do something')).toBe('do something');
+  });
+
+  test('returns null when no @paws mention', () => {
+    expect(parsePawsMention('just a regular comment')).toBeNull();
+  });
+});
+
+describe('parseWebhookEvent', () => {
+  test('parses valid issue_comment with @paws mention', () => {
+    const event = parseWebhookEvent(makeWebhookPayload());
+    expect(event).toEqual({
+      type: 'mention',
+      command: 'review this PR',
+      repo: 'org/repo',
+      sender: 'alice',
+      installationId: 12345,
+      prNumber: 42,
+      commentUrl: 'https://api.github.com/repos/org/repo/issues/comments/1',
+      issueUrl: 'https://api.github.com/repos/org/repo/issues/42',
+    });
+  });
+
+  test('returns null for comment without @paws', () => {
+    const payload = makeWebhookPayload({
+      comment: {
+        body: 'just a normal comment',
+        url: 'https://api.github.com/repos/org/repo/issues/comments/1',
+      },
+    });
+    expect(parseWebhookEvent(payload)).toBeNull();
+  });
+
+  test('returns null for action !== created', () => {
+    const payload = makeWebhookPayload({ action: 'edited' });
+    expect(parseWebhookEvent(payload)).toBeNull();
+  });
+
+  test('detects PR context from issue.pull_request field', () => {
+    // With pull_request field -> prNumber set
+    const prPayload = makeWebhookPayload();
+    const prEvent = parseWebhookEvent(prPayload);
+    expect(prEvent?.prNumber).toBe(42);
+
+    // Without pull_request field -> prNumber undefined
+    const issuePayload = makeWebhookPayload({
+      issue: {
+        number: 10,
+        url: 'https://api.github.com/repos/org/repo/issues/10',
+      },
+    });
+    const issueEvent = parseWebhookEvent(issuePayload);
+    expect(issueEvent?.prNumber).toBeUndefined();
+  });
+});

--- a/packages/integrations/src/github.ts
+++ b/packages/integrations/src/github.ts
@@ -1,0 +1,52 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import type { GitHubEvent } from './types.js';
+
+/** Verify GitHub webhook signature */
+export function verifyWebhookSignature(
+  payload: string,
+  signature: string,
+  secret: string,
+): boolean {
+  const expected = 'sha256=' + createHmac('sha256', secret).update(payload).digest('hex');
+  if (expected.length !== signature.length) return false;
+  return timingSafeEqual(Buffer.from(expected), Buffer.from(signature));
+}
+
+/** Parse @paws mention from comment body, extract command */
+export function parsePawsMention(body: string): string | null {
+  const match = body.match(/@paws\s+(.*)/i);
+  if (!match) return null;
+  return match[1]!.trim();
+}
+
+/** Parse a GitHub issue_comment webhook into a GitHubEvent (or null if not a @paws mention) */
+export function parseWebhookEvent(payload: Record<string, unknown>): GitHubEvent | null {
+  const action = payload.action as string;
+  if (action !== 'created') return null;
+
+  const comment = payload.comment as Record<string, unknown>;
+  const issue = payload.issue as Record<string, unknown>;
+  const repo = payload.repository as Record<string, unknown>;
+  const sender = payload.sender as Record<string, unknown>;
+  const installation = payload.installation as Record<string, unknown>;
+
+  if (!comment || !issue || !repo || !sender || !installation) return null;
+
+  const body = comment.body as string;
+  const command = parsePawsMention(body);
+  if (!command) return null;
+
+  const fullName = repo.full_name as string;
+  const prNumber = issue.pull_request ? (issue.number as number) : undefined;
+
+  return {
+    type: 'mention',
+    command,
+    repo: fullName,
+    sender: sender.login as string,
+    installationId: installation.id as number,
+    prNumber,
+    commentUrl: comment.url as string,
+    issueUrl: issue.url as string,
+  };
+}

--- a/packages/integrations/src/index.ts
+++ b/packages/integrations/src/index.ts
@@ -1,0 +1,8 @@
+export { verifyWebhookSignature, parsePawsMention, parseWebhookEvent } from './github.js';
+export { createGitHubAuth } from './github-auth.js';
+export type { GitHubAuth } from './github-auth.js';
+export { matchDaemon } from './router.js';
+export type { MatchResult } from './router.js';
+export { postComment } from './callback.js';
+export type { CallbackDeps } from './callback.js';
+export type { GitHubEvent, GitHubAppConfig, GitHubDaemon } from './types.js';

--- a/packages/integrations/src/router.test.ts
+++ b/packages/integrations/src/router.test.ts
@@ -1,0 +1,92 @@
+import { describe, test, expect } from 'vitest';
+import { matchDaemon } from './router.js';
+import type { GitHubEvent, GitHubDaemon } from './types.js';
+
+function makeEvent(overrides: Partial<GitHubEvent> = {}): GitHubEvent {
+  return {
+    type: 'mention',
+    command: 'review this PR',
+    repo: 'org/repo',
+    sender: 'alice',
+    installationId: 12345,
+    commentUrl: 'https://api.github.com/repos/org/repo/issues/comments/1',
+    issueUrl: 'https://api.github.com/repos/org/repo/issues/42',
+    ...overrides,
+  };
+}
+
+function makeDaemon(overrides: Partial<GitHubDaemon> = {}): GitHubDaemon {
+  return {
+    role: 'reviewer',
+    trigger: {
+      type: 'github',
+      repos: ['org/repo'],
+      events: ['issue_comment'],
+      command: 'review',
+    },
+    snapshot: 'agent-latest',
+    workload: { type: 'script', script: 'echo hi', env: {} },
+    ...overrides,
+  };
+}
+
+describe('matchDaemon', () => {
+  test('matches by exact repo + command', () => {
+    const daemon = makeDaemon();
+    const event = makeEvent({ command: 'review this PR' });
+    const result = matchDaemon(event, [daemon]);
+    expect(result).toEqual({ daemon, event });
+  });
+
+  test('matches wildcard repo', () => {
+    const daemon = makeDaemon({
+      trigger: { type: 'github', repos: ['*'], events: ['issue_comment'], command: 'review' },
+    });
+    const event = makeEvent({ repo: 'any/repo', command: 'review please' });
+    const result = matchDaemon(event, [daemon]);
+    expect(result).toEqual({ daemon, event });
+  });
+
+  test('prefers exact repo over wildcard', () => {
+    const wildcard = makeDaemon({
+      role: 'wildcard-reviewer',
+      trigger: { type: 'github', repos: ['*'], events: ['issue_comment'], command: 'review' },
+    });
+    const exact = makeDaemon({
+      role: 'exact-reviewer',
+      trigger: {
+        type: 'github',
+        repos: ['org/repo'],
+        events: ['issue_comment'],
+        command: 'review',
+      },
+    });
+    const event = makeEvent({ command: 'review this' });
+    const result = matchDaemon(event, [wildcard, exact]);
+    expect(result?.daemon.role).toBe('exact-reviewer');
+  });
+
+  test('matches daemon role when no command specified', () => {
+    const daemon = makeDaemon({
+      role: 'deploy',
+      trigger: { type: 'github', repos: ['org/repo'], events: ['issue_comment'] },
+    });
+    const event = makeEvent({ command: 'deploy to staging' });
+    const result = matchDaemon(event, [daemon]);
+    expect(result).toEqual({ daemon, event });
+  });
+
+  test('returns null when no match', () => {
+    const daemon = makeDaemon();
+    const event = makeEvent({ command: 'deploy something' });
+    const result = matchDaemon(event, [daemon]);
+    expect(result).toBeNull();
+  });
+
+  test('case-insensitive command matching', () => {
+    const daemon = makeDaemon();
+    const event = makeEvent({ command: 'REVIEW this PR' });
+    const result = matchDaemon(event, [daemon]);
+    expect(result).toEqual({ daemon, event });
+  });
+});

--- a/packages/integrations/src/router.ts
+++ b/packages/integrations/src/router.ts
@@ -1,0 +1,25 @@
+import type { GitHubEvent, GitHubDaemon } from './types.js';
+
+export interface MatchResult {
+  daemon: GitHubDaemon;
+  event: GitHubEvent;
+}
+
+/** Find the daemon that matches a GitHub event */
+export function matchDaemon(event: GitHubEvent, daemons: GitHubDaemon[]): MatchResult | null {
+  const candidates = daemons.filter((d) => {
+    const repoMatch = d.trigger.repos.includes('*') || d.trigger.repos.includes(event.repo);
+    if (!repoMatch) return false;
+
+    const expectedCommand = d.trigger.command ?? d.role;
+    return event.command.toLowerCase().startsWith(expectedCommand.toLowerCase());
+  });
+
+  if (candidates.length === 0) return null;
+
+  // Prefer most specific: explicit repo > wildcard
+  const specific = candidates.find((d) => d.trigger.repos.includes(event.repo));
+  const chosen = specific ?? candidates[0]!;
+
+  return { daemon: chosen, event };
+}

--- a/packages/integrations/src/types.ts
+++ b/packages/integrations/src/types.ts
@@ -1,0 +1,34 @@
+/** Event from GitHub webhook parsed for paws consumption */
+export interface GitHubEvent {
+  type: 'mention';
+  command: string;
+  repo: string;
+  sender: string;
+  installationId: number;
+  prNumber?: number | undefined;
+  commentUrl: string;
+  issueUrl: string;
+}
+
+/** Config for the GitHub integration */
+export interface GitHubAppConfig {
+  appId: string;
+  privateKey: string;
+  webhookSecret: string;
+}
+
+/** Daemon with a GitHub trigger (type-narrowed) */
+export interface GitHubDaemon {
+  role: string;
+  trigger: {
+    type: 'github';
+    repos: string[];
+    events: string[];
+    command?: string;
+  };
+  snapshot: string;
+  workload: { type: string; script: string; env: Record<string, string> };
+  resources?: { vcpus: number; memoryMB: number };
+  network?: unknown;
+  governance?: unknown;
+}

--- a/packages/integrations/tsconfig.json
+++ b/packages/integrations/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/integrations/vitest.config.ts
+++ b/packages/integrations/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+    coverage: {
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/*.test.ts', 'src/index.ts'],
+    },
+  },
+});

--- a/packages/types/src/daemon.ts
+++ b/packages/types/src/daemon.ts
@@ -29,11 +29,20 @@ export const WatchTriggerSchema = z.object({
   intervalMs: DurationMsSchema.default(60_000),
 });
 
+/** GitHub App trigger */
+export const GitHubTriggerSchema = z.object({
+  type: z.literal('github'),
+  repos: z.array(NonEmptyStringSchema).min(1),
+  events: z.array(NonEmptyStringSchema).default(['issue_comment']),
+  command: z.string().optional(),
+});
+
 /** Any trigger type */
 export const TriggerSchema = z.discriminatedUnion('type', [
   WebhookTriggerSchema,
   ScheduleTriggerSchema,
   WatchTriggerSchema,
+  GitHubTriggerSchema,
 ]);
 
 export type Trigger = z.infer<typeof TriggerSchema>;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -16,6 +16,7 @@ export {
   DaemonSessionSummarySchema,
   DaemonStatsSchema,
   DaemonStatus,
+  GitHubTriggerSchema,
   GovernanceSchema,
   ScheduleTriggerSchema,
   TriggerSchema,


### PR DESCRIPTION
## Summary

GitHub App integration for paws (roadmap #39, partial delivery). Users type `@paws <command>` in a PR comment, an agent spins up in an isolated Firecracker VM, runs the task, and posts results back as a comment. Zero secrets enter the VM.

**New package: `packages/integrations`**
- GitHub webhook handler with HMAC-SHA256 signature verification
- `@paws` mention parser with case-insensitive command extraction
- Daemon router: match GitHub events to daemons by repo + command (wildcard support)
- GitHub App JWT + installation token lifecycle (RS256, cached, auto-refresh <5min)
- Result callback: post agent output as PR comment with 3x retry on rate limits

**Daemon types: `GitHubTriggerSchema`**
- New trigger type `github` added to `TriggerSchema` discriminated union
- Fields: `repos` (array), `events` (default: issue_comment), `command` (optional)

**Control plane: `/webhooks/github` route**
- Webhook signature verification → @paws mention parsing → daemon matching → session dispatch
- Result callback listens to SessionEvents for session completion → posts comment via installation token
- Governance rate limiting applies to GitHub-triggered sessions

## Test Coverage

20 new tests in packages/integrations:
- 10 webhook tests (signature, mention parsing, event parsing)
- 6 router tests (exact match, wildcard, specificity, case-insensitive)
- 4 callback tests (success, retry on 429, non-retryable, exhausted retries)

## Test plan
- [x] All integrations tests pass (20 tests)
- [x] All types tests pass (98 tests)
- [x] All control-plane tests pass (115 tests)
- [x] `bun run check` passes (lint + typecheck + format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)