### PR TITLE
worker: add port readiness health check endpoint

### DIFF
--- a/apps/worker/src/routes.test.ts
+++ b/apps/worker/src/routes.test.ts
@@ -14,6 +14,7 @@ function createMockExecutor() {
       output: undefined,
       durationMs: 100,
     }),
+    getSessionConnection: vi.fn().mockReturnValue(undefined),
     get activeSessions() {
       return activeSessions;
     },
@@ -190,5 +191,49 @@ describe('GET /v1/sessions/:id', () => {
     expect(body.sessionId).toBe(sessionId);
     expect(body.status).toBe('running');
     expect(body.worker).toBe('test-worker');
+  });
+});
+
+describe('GET /v1/sessions/:id/health/:port', () => {
+  test('returns 404 when session not found', async () => {
+    const { app } = createApp();
+    const res = await app.request('/v1/sessions/unknown-id/health/3000');
+    expect(res.status).toBe(404);
+
+    const body = await res.json();
+    expect(body.error.code).toBe('SESSION_NOT_FOUND');
+  });
+
+  test('returns 400 for invalid port', async () => {
+    const { app } = createApp();
+    const res = await app.request('/v1/sessions/some-id/health/0');
+    expect(res.status).toBe(400);
+
+    const body = await res.json();
+    expect(body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  test('returns 400 for non-numeric port', async () => {
+    const { app } = createApp();
+    const res = await app.request('/v1/sessions/some-id/health/abc');
+    expect(res.status).toBe(400);
+
+    const body = await res.json();
+    expect(body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  test('returns ready false when TCP connect fails', async () => {
+    const { app, executor } = createApp();
+    executor.getSessionConnection.mockReturnValue({
+      guestIp: '127.0.0.1',
+      sshKeyPath: '/tmp/fake-key',
+    });
+
+    // Use a port that is almost certainly not listening
+    const res = await app.request('/v1/sessions/test-session/health/19999');
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.ready).toBe(false);
   });
 });

--- a/apps/worker/src/routes.ts
+++ b/apps/worker/src/routes.ts
@@ -178,6 +178,51 @@ export function createSessionApp(deps: AppDeps) {
     );
   });
 
+  // Port readiness health check — TCP probe a port inside a running VM
+  app.get('/v1/sessions/:id/health/:port', async (c) => {
+    const id = c.req.param('id');
+    const port = Number(c.req.param('port'));
+
+    if (!Number.isInteger(port) || port < 1 || port > 65535) {
+      return c.json(
+        {
+          error: {
+            code: 'VALIDATION_ERROR',
+            message: 'Port must be an integer between 1 and 65535',
+          },
+        },
+        400,
+      );
+    }
+
+    const conn = executor.getSessionConnection(id);
+    if (!conn) {
+      return c.json(
+        { error: { code: 'SESSION_NOT_FOUND', message: `Session ${id} not found or not running` } },
+        404,
+      );
+    }
+
+    try {
+      const socket = await Bun.connect({
+        hostname: conn.guestIp,
+        port,
+        socket: {
+          data() {},
+          open(s) {
+            s.end();
+          },
+          error() {},
+          connectError() {},
+        },
+      });
+      socket.end();
+      return c.json({ ready: true });
+    } catch {
+      return c.json({ ready: false });
+    }
+  });
+
   // --- Checkpoint / Rollback ---
 
   // Create a checkpoint (snapshot of the running VM)


### PR DESCRIPTION
## Summary

- Add `GET /v1/sessions/:id/health/:port` route that TCP-probes a port inside a running VM
- Returns `{ ready: true }` if the port is listening, `{ ready: false }` if not
- Uses `Bun.connect()` for a lightweight TCP check with implicit timeout
- Validates port range (1-65535) and returns 404 if session not found

## Context

PAWS-102: When a session exposes ports (e.g., a dev server on :3000), the dashboard needs to know if the port is actually listening before showing the preview iframe. This endpoint provides that readiness signal.

## Changes

- `apps/worker/src/routes.ts` — new health check route (~25 lines)
- `apps/worker/src/routes.test.ts` — 4 tests covering 404/400/ready:false cases

## Test plan

- [x] Typecheck passes (`tsc --build`)
- [x] All 56 unit tests pass (52 existing + 4 new)
- [ ] Manual test with a running session exposing a port

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new session health check endpoint (`/v1/sessions/:id/health/:port`) to verify TCP connectivity to a specified port on a session. Validates port numbers and returns connection readiness status with appropriate error codes for invalid ports or missing sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->