### PR TITLE
proxy: add structured JSON audit logging

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -345,6 +345,7 @@
       "name": "@paws/proxy",
       "version": "0.1.0",
       "dependencies": {
+        "@paws/logger": "workspace:*",
         "neverthrow": "catalog:",
       },
       "devDependencies": {

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -17,6 +17,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@paws/logger": "workspace:*",
     "neverthrow": "catalog:"
   },
   "devDependencies": {

--- a/packages/proxy/src/server.ts
+++ b/packages/proxy/src/server.ts
@@ -1,3 +1,6 @@
+import { createLogger } from '@paws/logger';
+import type { Logger } from '@paws/logger';
+
 import { matchesDomain, findCredentials, findDomainEntry } from './domain-match.js';
 import type { ProxyConfig, ProxyInstance } from './types.js';
 
@@ -15,6 +18,11 @@ import type { ProxyConfig, ProxyInstance } from './types.js';
 export function createProxy(config: ProxyConfig): ProxyInstance {
   const allowlist = Object.keys(config.domains);
 
+  const log: Logger = createLogger(
+    'proxy',
+    config.sessionId ? { sessionId: config.sessionId } : {},
+  );
+
   let httpServer: ReturnType<typeof Bun.serve> | undefined;
   let httpsServer: ReturnType<typeof Bun.serve> | undefined;
   let actualHttpPort = 0;
@@ -29,15 +37,22 @@ export function createProxy(config: ProxyConfig): ProxyInstance {
    * DRY helper used by both HTTP and HTTPS servers.
    */
   function forwardRequest(req: Request, protocol: 'http' | 'https'): Promise<Response> | Response {
+    const startTime = performance.now();
     const url = new URL(req.url);
     const hostname = url.hostname;
 
     if (!matchesDomain(hostname, allowlist)) {
+      log.warn('domain blocked', {
+        domain: hostname,
+        method: req.method,
+        path: url.pathname,
+      });
       return new Response('Blocked by network policy', { status: 403 });
     }
 
     const entry = findDomainEntry(hostname, config.domains);
     const creds = findCredentials(hostname, config.domains);
+    const credentialsInjected = creds != null && Object.keys(creds).length > 0;
 
     // Build upstream request with injected credentials
     const headers = new Headers(req.headers);
@@ -68,6 +83,18 @@ export function createProxy(config: ProxyConfig): ProxyInstance {
       }),
     ).then(
       (upstream) => {
+        const durationMs = Math.round(performance.now() - startTime);
+
+        log.info('request forwarded', {
+          domain: hostname,
+          method: req.method,
+          path: url.pathname,
+          statusCode: upstream.status,
+          durationMs,
+          credentialsInjected,
+          protocol,
+        });
+
         return new Response(upstream.body, {
           status: upstream.status,
           statusText: upstream.statusText,
@@ -75,6 +102,17 @@ export function createProxy(config: ProxyConfig): ProxyInstance {
         });
       },
       (_err) => {
+        const durationMs = Math.round(performance.now() - startTime);
+
+        log.error('upstream connection failed', {
+          domain: hostname,
+          method: req.method,
+          path: url.pathname,
+          durationMs,
+          credentialsInjected,
+          protocol,
+        });
+
         // Catch fetch errors to prevent credential headers from leaking in stack traces
         return new Response(`Upstream connection failed for ${hostname}`, { status: 502 });
       },
@@ -111,6 +149,13 @@ export function createProxy(config: ProxyConfig): ProxyInstance {
         });
         // httpsPort is listen.port + 1 by convention
       }
+
+      log.info('proxy started', {
+        host: config.listen.host,
+        httpPort: actualHttpPort,
+        httpsPort: caCert ? config.listen.port + 1 : null,
+        allowlistedDomains: allowlist.length,
+      });
     },
 
     async stop() {
@@ -123,6 +168,7 @@ export function createProxy(config: ProxyConfig): ProxyInstance {
         httpsServer = undefined;
       }
       started = false;
+      log.info('proxy stopped');
     },
 
     address() {

--- a/packages/proxy/src/types.ts
+++ b/packages/proxy/src/types.ts
@@ -20,6 +20,8 @@ export interface ProxyConfig {
   domains: Record<string, DomainEntry>;
   /** PEM-encoded CA cert + key for TLS MITM; auto-generated if omitted */
   ca?: { cert: string; key: string };
+  /** Session ID for audit log correlation */
+  sessionId?: string;
 }
 
 /** Handle to a running proxy instance */


### PR DESCRIPTION
## Summary

- Add structured JSON audit logging to the per-VM TLS MITM proxy using `@paws/logger`
- Every proxied request is logged with: timestamp, sessionId, domain, method, path, status code, duration (ms), whether credentials were injected, and protocol
- Credential **values** are never logged — only `credentialsInjected: true/false`
- Log levels: `info` for successful forwards, `warn` for blocked domains, `error` for upstream failures
- Proxy start/stop lifecycle events are also logged
- `ProxyConfig` gains an optional `sessionId` field for audit log correlation

## What was built

| File | Change |
|------|--------|
| `packages/proxy/src/server.ts` | Added audit logging around `forwardRequest()` and lifecycle methods |
| `packages/proxy/src/types.ts` | Added optional `sessionId` to `ProxyConfig` |
| `packages/proxy/package.json` | Added `@paws/logger` workspace dependency |

## Example log output

```json
{"ts":"2026-04-03T...","level":"info","component":"proxy","msg":"request forwarded","sessionId":"sess_abc","domain":"api.anthropic.com","method":"POST","path":"/v1/messages","statusCode":200,"durationMs":142,"credentialsInjected":true,"protocol":"https"}
{"ts":"2026-04-03T...","level":"warn","component":"proxy","msg":"domain blocked","sessionId":"sess_abc","domain":"evil.com","method":"GET","path":"/"}
{"ts":"2026-04-03T...","level":"error","component":"proxy","msg":"upstream connection failed","sessionId":"sess_abc","domain":"api.anthropic.com","method":"POST","path":"/v1/messages","durationMs":5003,"credentialsInjected":true,"protocol":"https"}
```

## Decisions

- Used `performance.now()` for sub-ms timing precision
- `sessionId` is optional — proxy works without it (logs just omit the field)
- No refactoring of existing proxy logic — logging is purely additive
- Pre-existing integration test failures (port conflict, Bun global mock) are unrelated

## Test plan

- [x] `bun run typecheck` passes (40/40 tasks)
- [x] `bun test packages/proxy/src/domain-match.test.ts` passes (23/23)
- [x] Pre-existing integration test failures confirmed on `main` (not introduced by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Proxy now includes structured logging for lifecycle events (startup and shutdown).
  * Request handling logs capture response status, duration, and connection details.
  * Added optional session ID configuration for request correlation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->