### PR TITLE
feat(dashboard): observability page — PAWS-66

### DIFF
--- a/apps/dashboard/src/api/client.ts
+++ b/apps/dashboard/src/api/client.ts
@@ -387,6 +387,27 @@ export async function getAuditStats(): Promise<AuditStats> {
   return res.json();
 }
 
+// --- Cost / Observability ---
+
+export interface CostByDaemon {
+  role: string;
+  totalInvocations: number;
+  totalVcpuSeconds: number;
+  totalDurationMs: number;
+}
+
+export interface CostSummary {
+  totalVcpuSeconds: number;
+  totalSessions: number;
+  byDaemon: CostByDaemon[];
+}
+
+export async function getCostSummary(): Promise<CostSummary> {
+  const res = await fetch('/v1/fleet/cost', { headers: apiKeyHeaders() });
+  if (!res.ok) throw new Error(`Failed to fetch cost summary: ${res.status}`);
+  return res.json();
+}
+
 // --- Browser (computer-use) ---
 
 export async function takeBrowserScreenshot(sessionId: string): Promise<ScreenshotResponse> {

--- a/apps/dashboard/src/components/Layout.tsx
+++ b/apps/dashboard/src/components/Layout.tsx
@@ -107,6 +107,12 @@ function SidebarNav({
         collapsed={collapsed}
       />
       <SidebarLink to="/mcp" label="MCP Servers" onClick={onNavigate} collapsed={collapsed} />
+      <SidebarLink
+        to="/observability"
+        label="Observability"
+        onClick={onNavigate}
+        collapsed={collapsed}
+      />
       <SidebarLink to="/audit" label="Audit Log" onClick={onNavigate} collapsed={collapsed} />
       <SidebarLink to="/settings" label="Settings" onClick={onNavigate} collapsed={collapsed} />
       <SidebarLink to="/setup" label="Setup Wizard" onClick={onNavigate} collapsed={collapsed} />

--- a/apps/dashboard/src/pages/Observability.tsx
+++ b/apps/dashboard/src/pages/Observability.tsx
@@ -1,0 +1,206 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { getAuditStats, getCostSummary, type AuditStats, type CostSummary } from '../api/client.js';
+import { Alert, AlertDescription } from '../components/ui/alert.js';
+import { Card, CardContent } from '../components/ui/card.js';
+import { Skeleton } from '../components/ui/skeleton.js';
+import { StatCard } from '../components/StatCard.js';
+
+function formatDuration(ms: number): string {
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ${seconds % 60}s`;
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h ${minutes % 60}m`;
+}
+
+function formatNumber(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return n.toLocaleString();
+}
+
+export function Observability() {
+  const [cost, setCost] = useState<CostSummary | null>(null);
+  const [stats, setStats] = useState<AuditStats | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchData = useCallback(async () => {
+    try {
+      const [costResult, statsResult] = await Promise.all([getCostSummary(), getAuditStats()]);
+      setCost(costResult);
+      setStats(statsResult);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void fetchData();
+    const id = setInterval(() => void fetchData(), 10_000);
+    return () => clearInterval(id);
+  }, [fetchData]);
+
+  const avgCostPerSession =
+    cost && cost.totalSessions > 0 ? (cost.totalVcpuSeconds / cost.totalSessions).toFixed(1) : '0';
+
+  const eventsToday = stats ? Object.values(stats.last24h).reduce((a, b) => a + b, 0) : 0;
+  const eventsThisWeek = stats ? Object.values(stats.last7d).reduce((a, b) => a + b, 0) : 0;
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <h1 className="text-lg font-semibold">Observability</h1>
+      </div>
+
+      {/* Cost Summary Cards */}
+      {loading ? (
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          {Array.from({ length: 4 }, (_, i) => (
+            <Skeleton key={i} className="h-20" />
+          ))}
+        </div>
+      ) : error ? (
+        <Alert variant="destructive" className="bg-red-400/10 border-red-400/20 text-red-400">
+          <AlertDescription>Failed to load observability data: {error.message}</AlertDescription>
+        </Alert>
+      ) : (
+        <>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            <StatCard
+              label="Total vCPU-seconds"
+              value={formatNumber(cost?.totalVcpuSeconds ?? 0)}
+            />
+            <StatCard
+              label="Total Sessions"
+              value={formatNumber(cost?.totalSessions ?? 0)}
+              color="emerald"
+            />
+            <StatCard label="Avg vCPU-sec / Session" value={avgCostPerSession} color="amber" />
+            <StatCard label="Events (24h)" value={formatNumber(eventsToday)} />
+          </div>
+
+          {/* Activity Summary */}
+          <div>
+            <h2 className="text-sm font-semibold text-zinc-400 uppercase tracking-wide mb-3">
+              Activity Summary
+            </h2>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              <Card>
+                <CardContent className="p-4">
+                  <p className="text-xs text-muted-foreground uppercase tracking-wide">Last 24h</p>
+                  <p className="mt-1 text-2xl font-bold text-foreground">
+                    {formatNumber(eventsToday)}
+                  </p>
+                  {stats && (
+                    <div className="mt-2 space-y-1">
+                      {Object.entries(stats.last24h).map(([category, count]) => (
+                        <div key={category} className="flex justify-between text-xs">
+                          <span className="text-zinc-500">{category}</span>
+                          <span className="text-zinc-300">{count}</span>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </CardContent>
+              </Card>
+              <Card>
+                <CardContent className="p-4">
+                  <p className="text-xs text-muted-foreground uppercase tracking-wide">Last 7d</p>
+                  <p className="mt-1 text-2xl font-bold text-foreground">
+                    {formatNumber(eventsThisWeek)}
+                  </p>
+                  {stats && (
+                    <div className="mt-2 space-y-1">
+                      {Object.entries(stats.last7d).map(([category, count]) => (
+                        <div key={category} className="flex justify-between text-xs">
+                          <span className="text-zinc-500">{category}</span>
+                          <span className="text-zinc-300">{count}</span>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </CardContent>
+              </Card>
+              <Card>
+                <CardContent className="p-4">
+                  <p className="text-xs text-muted-foreground uppercase tracking-wide">
+                    Total Events
+                  </p>
+                  <p className="mt-1 text-2xl font-bold text-foreground">
+                    {formatNumber(stats?.total ?? 0)}
+                  </p>
+                </CardContent>
+              </Card>
+            </div>
+          </div>
+
+          {/* Cost by Daemon */}
+          {cost && cost.byDaemon.length > 0 && (
+            <div>
+              <h2 className="text-sm font-semibold text-zinc-400 uppercase tracking-wide mb-3">
+                Cost by Daemon
+              </h2>
+              <Card className="bg-zinc-900 border-zinc-800 py-0 shadow-none overflow-hidden">
+                <CardContent className="p-0">
+                  {/* Table header */}
+                  <div className="px-4 py-2 flex items-center gap-3 border-b border-zinc-800 text-xs text-zinc-600 font-medium">
+                    <span className="flex-1">Role</span>
+                    <span className="w-28 text-right">Invocations</span>
+                    <span className="w-32 text-right">vCPU-seconds</span>
+                    <span className="w-28 text-right">Avg Duration</span>
+                  </div>
+                  {/* Rows */}
+                  {cost.byDaemon.map((daemon) => (
+                    <div
+                      key={daemon.role}
+                      className="px-4 py-3 flex items-center gap-3 border-b border-zinc-800 last:border-b-0 hover:bg-zinc-800/30 transition-colors"
+                    >
+                      <span className="flex-1 text-sm text-zinc-300 font-mono truncate">
+                        {daemon.role}
+                      </span>
+                      <span className="w-28 text-right text-sm text-zinc-400">
+                        {formatNumber(daemon.totalInvocations)}
+                      </span>
+                      <span className="w-32 text-right text-sm text-zinc-400">
+                        {formatNumber(daemon.totalVcpuSeconds)}
+                      </span>
+                      <span className="w-28 text-right text-sm text-zinc-500">
+                        {daemon.totalInvocations > 0
+                          ? formatDuration(daemon.totalDurationMs / daemon.totalInvocations)
+                          : '-'}
+                      </span>
+                    </div>
+                  ))}
+                </CardContent>
+              </Card>
+            </div>
+          )}
+
+          {/* Empty state for cost by daemon */}
+          {cost && cost.byDaemon.length === 0 && (
+            <Card className="bg-zinc-900 border-zinc-800 py-0 shadow-none">
+              <CardContent className="p-8 text-center space-y-3">
+                <pre className="text-zinc-600 text-xs leading-tight font-mono inline-block">
+                  {` /\\_/\\
+( o.o )  no daemon activity yet
+ > ^ <`}
+                </pre>
+                <p className="text-zinc-400 text-sm">No cost data recorded.</p>
+                <p className="text-zinc-500 text-xs">
+                  Cost breakdown will appear here as daemons run sessions.
+                </p>
+              </CardContent>
+            </Card>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/dashboard/src/router.tsx
+++ b/apps/dashboard/src/router.tsx
@@ -122,6 +122,9 @@ const Setup = lazy(() => import('./pages/Setup.js').then((m) => ({ default: m.Se
 const Snapshots = lazy(() =>
   import('./pages/Snapshots.js').then((m) => ({ default: m.Snapshots })),
 );
+const Observability = lazy(() =>
+  import('./pages/Observability.js').then((m) => ({ default: m.Observability })),
+);
 const Templates = lazy(() =>
   import('./pages/Templates.js').then((m) => ({ default: m.Templates })),
 );
@@ -229,6 +232,12 @@ const mcpRoute = createRoute({
   component: lazyPage(McpServers, <CardGridSkeleton />),
 });
 
+const observabilityRoute = createRoute({
+  getParentRoute: () => layoutRoute,
+  path: '/observability',
+  component: lazyPage(Observability, <DashboardSkeleton />),
+});
+
 const auditRoute = createRoute({
   getParentRoute: () => layoutRoute,
   path: '/audit',
@@ -249,6 +258,7 @@ const routeTree = rootRoute.addChildren([
     sessionDetailRoute,
     integrationsRoute,
     mcpRoute,
+    observabilityRoute,
     auditRoute,
   ]),
 ]);


### PR DESCRIPTION
## Summary

- Adds `/observability` dashboard page with cost and activity data
- **Cost summary cards**: total vCPU-seconds, total sessions, avg vCPU-sec per session, events (24h)
- **Activity summary**: last 24h / last 7d / total event counts with per-category breakdown (from `GET /v1/audit/stats`)
- **Cost by daemon table**: role, invocations, total vCPU-seconds, avg duration (from `GET /v1/fleet/cost`)
- Adds `getCostSummary()` + `CostSummary`/`CostByDaemon` types to the API client
- Adds route at `/observability` and sidebar nav link under Configuration section

## Decisions

- Placed nav link under Configuration section between MCP Servers and Audit Log — observability is operational, not infrastructure
- Used `DashboardSkeleton` loading fallback (stat cards + content) matching Fleet page pattern
- 10s polling interval (vs 5s for Fleet) since cost data changes less frequently
- No charts library — tables and cards only, as specified

## Test plan

- [ ] Verify typecheck passes (`bun run typecheck` -- confirmed locally)
- [ ] Navigate to `/observability` in dashboard
- [ ] Verify cost cards render with data from `/v1/fleet/cost`
- [ ] Verify activity summary renders with data from `/v1/audit/stats`
- [ ] Verify cost-by-daemon table renders with per-daemon breakdown
- [ ] Verify empty state cat ASCII art when no daemon data exists
- [ ] Verify sidebar link appears and highlights when active

🤖 Generated with [Claude Code](https://claude.com/claude-code)