### PR TITLE
feat: distributed tracing with OpenTelemetry + Grafana Tempo

### DIFF
--- a/apps/control-plane/package.json
+++ b/apps/control-plane/package.json
@@ -39,6 +39,7 @@
     "@paws/provider-hetzner-cloud": "workspace:*",
     "@paws/providers": "workspace:*",
     "@paws/provisioner": "workspace:*",
+    "@paws/telemetry": "workspace:*",
     "better-sqlite3": "catalog:",
     "drizzle-orm": "catalog:",
     "hono": "catalog:",

--- a/apps/control-plane/src/app.ts
+++ b/apps/control-plane/src/app.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 
 import { OpenAPIHono } from '@hono/zod-openapi';
 import { createLogger } from '@paws/logger';
+import { tracingMiddleware } from '@paws/telemetry';
 import type { Hono } from 'hono';
 import {
   verifyWebhookSignature,
@@ -263,6 +264,9 @@ export async function createControlPlaneApp(deps: ControlPlaneDeps) {
   // If OIDC is configured, init the middleware with env vars so @hono/oidc-auth
   // can discover the provider and validate sessions.
   const app = new OpenAPIHono();
+
+  // --- Distributed tracing (before all other middleware) ---
+  app.use('*', tracingMiddleware('control-plane'));
 
   if (deps.oidc) {
     const { initOidcAuthMiddleware } = await import('@hono/oidc-auth');

--- a/apps/control-plane/src/server.ts
+++ b/apps/control-plane/src/server.ts
@@ -1,10 +1,21 @@
 import { createBunWebSocket } from 'hono/bun';
 
+import { initTracing, activeTraceId, activeSpanId } from '@paws/telemetry';
+import { setGlobalLogEnricher } from '@paws/logger';
+
 import { createControlPlaneApp } from './app.js';
 import { createK8sDiscovery } from './discovery/k8s.js';
 import { createWorkerRegistry } from './discovery/registry.js';
 import { createStaticDiscovery } from './discovery/static.js';
 import { createDatabase } from './db/index.js';
+
+// --- OpenTelemetry tracing (must init before Hono app) ---
+initTracing({ serviceName: 'control-plane' });
+setGlobalLogEnricher(() => {
+  const traceId = activeTraceId();
+  const spanId = activeSpanId();
+  return traceId ? { traceId, spanId } : {};
+});
 
 const PORT = parseInt(process.env['PORT'] ?? '4000', 10);
 const API_KEY = process.env['API_KEY'] ?? 'paws-dev-key';

--- a/apps/control-plane/src/worker-client.ts
+++ b/apps/control-plane/src/worker-client.ts
@@ -1,4 +1,5 @@
 import type { CreateSessionRequest } from '@paws/domain-session';
+import { injectTraceHeaders } from '@paws/telemetry';
 
 export interface WorkerHealth {
   status: string;
@@ -39,21 +40,25 @@ export interface WorkerClient {
 export function createWorkerClient(baseUrl: string): WorkerClient {
   return {
     async health() {
-      const res = await fetch(`${baseUrl}/health`);
+      const res = await fetch(`${baseUrl}/health`, {
+        headers: injectTraceHeaders(),
+      });
       return (await res.json()) as WorkerHealth;
     },
 
     async createSession(sessionId, request) {
       const res = await fetch(`${baseUrl}/v1/sessions`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: injectTraceHeaders({ 'Content-Type': 'application/json' }),
         body: JSON.stringify({ ...request, sessionId }),
       });
       return (await res.json()) as { sessionId: string; status: string };
     },
 
     async getSession(sessionId) {
-      const res = await fetch(`${baseUrl}/v1/sessions/${sessionId}`);
+      const res = await fetch(`${baseUrl}/v1/sessions/${sessionId}`, {
+        headers: injectTraceHeaders(),
+      });
       if (res.status === 404) return undefined;
       return (await res.json()) as WorkerSessionResult;
     },
@@ -61,7 +66,7 @@ export function createWorkerClient(baseUrl: string): WorkerClient {
     async buildSnapshot(jobId, snapshotId, config) {
       await fetch(`${baseUrl}/v1/snapshots/${snapshotId}/build`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: injectTraceHeaders({ 'Content-Type': 'application/json' }),
         body: JSON.stringify({ jobId, ...config }),
       });
     },

--- a/apps/control-plane/tsconfig.json
+++ b/apps/control-plane/tsconfig.json
@@ -22,6 +22,7 @@
     { "path": "../../packages/logger" },
     { "path": "../../packages/providers" },
     { "path": "../../packages/provisioner" },
+    { "path": "../../packages/telemetry" },
     { "path": "../../providers/aws-ec2" },
     { "path": "../../providers/hetzner-cloud" }
   ]

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -29,6 +29,7 @@
     "@paws/runtime": "workspace:*",
     "@paws/runtime-firecracker": "workspace:*",
     "@paws/snapshot-store": "workspace:*",
+    "@paws/telemetry": "workspace:*",
     "hono": "catalog:",
     "neverthrow": "catalog:",
     "prom-client": "catalog:"

--- a/apps/worker/src/routes.ts
+++ b/apps/worker/src/routes.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 
 import { Hono } from 'hono';
 import { createLogger } from '@paws/logger';
+import { tracingMiddleware } from '@paws/telemetry';
 import { BrowserActionSchema } from '@paws/domain-browser';
 import { SnapshotBuildRequestSchema } from '@paws/domain-snapshot';
 import { CreateSessionRequestSchema } from '@paws/domain-session';
@@ -28,6 +29,7 @@ const startTime = Date.now();
 /** Create the Hono app with all worker routes */
 export function createSessionApp(deps: AppDeps) {
   const app = new Hono();
+  app.use('*', tracingMiddleware('worker'));
   const { executor, semaphore, workerName, syncLoop } = deps;
   const metrics = createWorkerMetrics({ semaphore, executor, workerName });
   const sessionResults = new Map<

--- a/apps/worker/src/server.ts
+++ b/apps/worker/src/server.ts
@@ -1,5 +1,14 @@
-import { createLogger } from '@paws/logger';
+import { createLogger, setGlobalLogEnricher } from '@paws/logger';
+import { initTracing, activeTraceId, activeSpanId } from '@paws/telemetry';
 import { createPortPool } from '@paws/firecracker';
+
+// --- OpenTelemetry tracing (must init before Hono app) ---
+initTracing({ serviceName: 'worker' });
+setGlobalLogEnricher(() => {
+  const traceId = activeTraceId();
+  const spanId = activeSpanId();
+  return traceId ? { traceId, spanId } : {};
+});
 import { createFirecrackerRuntime } from '@paws/runtime-firecracker';
 import { createRuntimeRegistry } from '@paws/runtime';
 

--- a/apps/worker/tsconfig.json
+++ b/apps/worker/tsconfig.json
@@ -16,6 +16,7 @@
     { "path": "../../packages/proxy" },
     { "path": "../../packages/runtime" },
     { "path": "../../packages/runtime-firecracker" },
-    { "path": "../../packages/snapshot-store" }
+    { "path": "../../packages/snapshot-store" },
+    { "path": "../../packages/telemetry" }
   ]
 }

--- a/bun.lock
+++ b/bun.lock
@@ -43,6 +43,7 @@
         "@paws/provider-hetzner-cloud": "workspace:*",
         "@paws/providers": "workspace:*",
         "@paws/provisioner": "workspace:*",
+        "@paws/telemetry": "workspace:*",
         "better-sqlite3": "catalog:",
         "drizzle-orm": "catalog:",
         "hono": "catalog:",
@@ -127,6 +128,7 @@
         "@paws/runtime": "workspace:*",
         "@paws/runtime-firecracker": "workspace:*",
         "@paws/snapshot-store": "workspace:*",
+        "@paws/telemetry": "workspace:*",
         "hono": "catalog:",
         "neverthrow": "catalog:",
         "prom-client": "catalog:",
@@ -398,6 +400,23 @@
         "@aws-sdk/client-s3": "^3.800.0",
         "@aws-sdk/lib-storage": "^3.800.0",
         "neverthrow": "catalog:",
+      },
+      "devDependencies": {
+        "vitest": "catalog:",
+      },
+    },
+    "packages/telemetry": {
+      "name": "@paws/telemetry",
+      "version": "0.1.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/context-async-hooks": "^2.6.1",
+        "@opentelemetry/core": "^2.6.1",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.214.0",
+        "@opentelemetry/resources": "^2.6.1",
+        "@opentelemetry/sdk-trace-base": "^2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.40.0",
+        "hono": "catalog:",
       },
       "devDependencies": {
         "vitest": "catalog:",
@@ -883,6 +902,28 @@
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 
+    "@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.214.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA=="],
+
+    "@opentelemetry/context-async-hooks": ["@opentelemetry/context-async-hooks@2.6.1", "", { "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-XHzhwRNkBpeP8Fs/qjGrAf9r9PRv67wkJQ/7ZPaBQQ68DYlTBBx5MF9LvPx7mhuXcDessKK2b+DcxqwpgkcivQ=="],
+
+    "@opentelemetry/core": ["@opentelemetry/core@2.6.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g=="],
+
+    "@opentelemetry/exporter-trace-otlp-http": ["@opentelemetry/exporter-trace-otlp-http@0.214.0", "", { "dependencies": { "@opentelemetry/core": "2.6.1", "@opentelemetry/otlp-exporter-base": "0.214.0", "@opentelemetry/otlp-transformer": "0.214.0", "@opentelemetry/resources": "2.6.1", "@opentelemetry/sdk-trace-base": "2.6.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-kIN8nTBMgV2hXzV/a20BCFilPZdAIMYYJGSgfMMRm/Xa+07y5hRDS2Vm12A/z8Cdu3Sq++ZvJfElokX2rkgGgw=="],
+
+    "@opentelemetry/otlp-exporter-base": ["@opentelemetry/otlp-exporter-base@0.214.0", "", { "dependencies": { "@opentelemetry/core": "2.6.1", "@opentelemetry/otlp-transformer": "0.214.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-u1Gdv0/E9wP+apqWf7Wv2npXmgJtxsW2XL0TEv9FZloTZRuMBKmu8cYVXwS4Hm3q/f/3FuCnPTgiwYvIqRSpRg=="],
+
+    "@opentelemetry/otlp-transformer": ["@opentelemetry/otlp-transformer@0.214.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.214.0", "@opentelemetry/core": "2.6.1", "@opentelemetry/resources": "2.6.1", "@opentelemetry/sdk-logs": "0.214.0", "@opentelemetry/sdk-metrics": "2.6.1", "@opentelemetry/sdk-trace-base": "2.6.1", "protobufjs": "^7.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-DSaYcuBRh6uozfsWN3R8HsN0yDhCuWP7tOFdkUOVaWD1KVJg8m4qiLUsg/tNhTLS9HUYUcwNpwL2eroLtsZZ/w=="],
+
+    "@opentelemetry/resources": ["@opentelemetry/resources@2.6.1", "", { "dependencies": { "@opentelemetry/core": "2.6.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-lID/vxSuKWXM55XhAKNoYXu9Cutoq5hFdkbTdI/zDKQktXzcWBVhNsOkiZFTMU9UtEWuGRNe0HUgmsFldIdxVA=="],
+
+    "@opentelemetry/sdk-logs": ["@opentelemetry/sdk-logs@0.214.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.214.0", "@opentelemetry/core": "2.6.1", "@opentelemetry/resources": "2.6.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.4.0 <1.10.0" } }, "sha512-zf6acnScjhsaBUU22zXZ/sLWim1dfhUAbGXdMmHmNG3LfBnQ3DKsOCITb2IZwoUsNNMTogqFKBnlIPPftUgGwA=="],
+
+    "@opentelemetry/sdk-metrics": ["@opentelemetry/sdk-metrics@2.6.1", "", { "dependencies": { "@opentelemetry/core": "2.6.1", "@opentelemetry/resources": "2.6.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0 <1.10.0" } }, "sha512-9t9hJHX15meBy2NmTJxL+NJfXmnausR2xUDvE19XQce0Qi/GBtDGamU8nS1RMbdgDmhgpm3VaOu2+fiS/SfTpQ=="],
+
+    "@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.6.1", "", { "dependencies": { "@opentelemetry/core": "2.6.1", "@opentelemetry/resources": "2.6.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-r86ut4T1e8vNwB35CqCcKd45yzqH6/6Wzvpk2/cZB8PsPLlZFTvrh8yfOS3CYZYcUmAx4hHTZJ8AO8Dj8nrdhw=="],
+
+    "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.40.0", "", {}, "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw=="],
+
     "@oslojs/encoding": ["@oslojs/encoding@1.1.0", "", {}, "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ=="],
 
     "@oxc-parser/binding-android-arm-eabi": ["@oxc-parser/binding-android-arm-eabi@0.121.0", "", { "os": "android", "cpu": "arm" }, "sha512-n07FQcySwOlzap424/PLMtOkbS7xOu8nsJduKL8P3COGHKgKoDYXwoAHCbChfgFpHnviehrLWIPX0lKGtbEk/A=="],
@@ -1115,9 +1156,31 @@
 
     "@paws/snapshot-store": ["@paws/snapshot-store@workspace:packages/snapshot-store"],
 
+    "@paws/telemetry": ["@paws/telemetry@workspace:packages/telemetry"],
+
     "@paws/typescript-config": ["@paws/typescript-config@workspace:packages/typescript-config"],
 
     "@paws/worker": ["@paws/worker@workspace:apps/worker"],
+
+    "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
+
+    "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],
+
+    "@protobufjs/codegen": ["@protobufjs/codegen@2.0.4", "", {}, "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="],
+
+    "@protobufjs/eventemitter": ["@protobufjs/eventemitter@1.1.0", "", {}, "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="],
+
+    "@protobufjs/fetch": ["@protobufjs/fetch@1.1.0", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.1", "@protobufjs/inquire": "^1.1.0" } }, "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ=="],
+
+    "@protobufjs/float": ["@protobufjs/float@1.0.2", "", {}, "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="],
+
+    "@protobufjs/inquire": ["@protobufjs/inquire@1.1.0", "", {}, "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="],
+
+    "@protobufjs/path": ["@protobufjs/path@1.1.2", "", {}, "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="],
+
+    "@protobufjs/pool": ["@protobufjs/pool@1.1.0", "", {}, "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="],
+
+    "@protobufjs/utf8": ["@protobufjs/utf8@1.1.0", "", {}, "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="],
 
     "@radix-ui/primitive": ["@radix-ui/primitive@1.1.3", "", {}, "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg=="],
 
@@ -2139,6 +2202,8 @@
 
     "log-update": ["log-update@6.1.0", "", { "dependencies": { "ansi-escapes": "^7.0.0", "cli-cursor": "^5.0.0", "slice-ansi": "^7.1.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w=="],
 
+    "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
+
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
 
     "lru-cache": ["lru-cache@11.2.7", "", {}, "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA=="],
@@ -2454,6 +2519,8 @@
     "prompts": ["prompts@2.4.2", "", { "dependencies": { "kleur": "^3.0.3", "sisteransi": "^1.0.5" } }, "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q=="],
 
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
+
+    "protobufjs": ["protobufjs@7.5.4", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg=="],
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
@@ -3009,6 +3076,8 @@
 
     "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
 
+    "protobufjs/@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
+
     "rc/strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
 
     "read-yaml-file/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
@@ -3152,6 +3221,8 @@
     "log-update/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "ora/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "protobufjs/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "read-yaml-file/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,8 +57,9 @@ services:
       OIDC_REDIRECT_URI: '${OIDC_REDIRECT_URI:-}'
       OIDC_AUTH_EXTERNAL_URL: '${OIDC_AUTH_EXTERNAL_URL:-}'
       AUTH_SECRET: '${AUTH_SECRET:-change-me-to-a-random-32-char-string}'
-      # Metrics
+      # Metrics + Tracing
       VICTORIAMETRICS_URL: 'http://victoriametrics:8428'
+      OTEL_EXPORTER_OTLP_ENDPOINT: 'http://tempo:4318'
     healthcheck:
       test: ['CMD', 'wget', '-qO-', 'http://localhost:3000/health']
       interval: 15s
@@ -96,11 +97,30 @@ services:
     volumes:
       - vm-data:/victoria-metrics-data
       - ./infra/victoriametrics/scrape.compose.yml:/etc/victoria-metrics/scrape.yml:ro
+      - ./infra/victoriametrics/alerts.yml:/etc/victoria-metrics/alerts.yml:ro
     command:
       - '--storageDataPath=/victoria-metrics-data'
       - '--retentionPeriod=30d'
       - '--promscrape.config=/etc/victoria-metrics/scrape.yml'
+      - '--rule=/etc/victoria-metrics/alerts.yml'
       - '--httpListenAddr=:8428'
+
+  # ── Tempo (Distributed Tracing) ───────────────────────────────────────
+  tempo:
+    image: grafana/tempo:2.7.2
+    container_name: paws-tempo
+    restart: unless-stopped
+    networks:
+      - paws
+    expose:
+      - '3200' # Tempo HTTP API
+      - '4317' # OTLP gRPC
+      - '4318' # OTLP HTTP
+    volumes:
+      - tempo-data:/var/tempo
+      - ./infra/tempo/tempo-config.yml:/etc/tempo/config.yml:ro
+    command:
+      - '-config.file=/etc/tempo/config.yml'
 
   # ── Loki (Log Aggregation) ─────────────────────────────────────────────
   loki:
@@ -159,4 +179,5 @@ volumes:
   gateway-data:
   vm-data:
   loki-data:
+  tempo-data:
   grafana-data:

--- a/infra/grafana/datasources.yml
+++ b/infra/grafana/datasources.yml
@@ -1,4 +1,4 @@
-# Grafana datasource provisioning — auto-connects to VictoriaMetrics.
+# Grafana datasource provisioning — metrics, logs, and traces.
 apiVersion: 1
 
 datasources:
@@ -15,3 +15,34 @@ datasources:
     url: http://loki:3100
     isDefault: false
     editable: false
+    jsonData:
+      derivedFields:
+        - datasourceUid: tempo
+          matcherRegex: '"traceId":"([a-f0-9]+)"'
+          name: TraceID
+          url: '$${__value.raw}'
+          urlDisplayLabel: View Trace
+
+  - name: Tempo
+    uid: tempo
+    type: tempo
+    access: proxy
+    url: http://tempo:3200
+    isDefault: false
+    editable: false
+    jsonData:
+      tracesToLogsV2:
+        datasourceUid: loki
+        filterByTraceID: true
+        filterBySpanID: false
+        tags:
+          - key: service.name
+            value: compose_service
+      tracesToMetrics:
+        datasourceUid: VictoriaMetrics
+      serviceMap:
+        datasourceUid: VictoriaMetrics
+      nodeGraph:
+        enabled: true
+      lokiSearch:
+        datasourceUid: loki

--- a/infra/tempo/tempo-config.yml
+++ b/infra/tempo/tempo-config.yml
@@ -1,0 +1,36 @@
+stream_over_http_enabled: true
+
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: 0.0.0.0:4317
+        http:
+          endpoint: 0.0.0.0:4318
+
+storage:
+  trace:
+    backend: local
+    local:
+      path: /var/tempo/traces
+    wal:
+      path: /var/tempo/wal
+
+metrics_generator:
+  registry:
+    external_labels:
+      source: tempo
+  storage:
+    path: /var/tempo/generator/wal
+    remote_write:
+      - url: http://victoriametrics:8428/api/v1/write
+        send_exemplars: true
+
+overrides:
+  defaults:
+    metrics_generator:
+      processors: [service-graphs, span-metrics]

--- a/infra/victoriametrics/alerts.yml
+++ b/infra/victoriametrics/alerts.yml
@@ -1,0 +1,87 @@
+groups:
+  - name: paws-availability
+    interval: 30s
+    rules:
+      - alert: WorkerDown
+        expr: paws_workers_healthy == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: No healthy workers available
+          description: All workers have been unhealthy for more than 2 minutes. No sessions can be scheduled.
+
+      - alert: WorkerDegraded
+        expr: paws_workers_healthy < paws_workers_total
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: '{{ $value }} of {{ with printf `paws_workers_total{instance="%s"}` $labels.instance }}{{ . | query | first | value }}{{ end }} workers unhealthy'
+          description: One or more workers have been unhealthy for 5+ minutes.
+
+      - alert: ControlPlaneDown
+        expr: up{job="paws-control-plane"} == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: Control plane is unreachable
+          description: VictoriaMetrics cannot scrape the control plane metrics endpoint.
+
+  - name: paws-sessions
+    interval: 30s
+    rules:
+      - alert: HighSessionFailureRate
+        expr: |
+          (
+            rate(paws_sessions_total{status="failed"}[5m])
+            / on() clamp_min(rate(paws_sessions_total[5m]), 0.001)
+          ) > 0.25
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: Session failure rate above 25%
+          description: More than 25% of sessions have been failing over the last 5 minutes.
+
+      - alert: SessionQueueBacklog
+        expr: paws_worker_sessions_queued > 5
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'Worker {{ $labels.worker }} has {{ $value }} queued sessions'
+          description: Sessions are backing up in the queue, which may indicate insufficient capacity.
+
+      - alert: FleetCapacityExhausted
+        expr: (paws_fleet_capacity_used / clamp_min(paws_fleet_capacity_total, 1)) > 0.9
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: Fleet capacity above 90%
+          description: 'Fleet utilization is {{ $value | humanizePercentage }}. Consider scaling up.'
+
+  - name: paws-latency
+    interval: 30s
+    rules:
+      - alert: HighAPILatency
+        expr: |
+          histogram_quantile(0.95, rate(paws_http_request_duration_seconds_bucket[5m])) > 5
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: API p95 latency above 5s
+          description: The 95th percentile HTTP request latency has exceeded 5 seconds for 5+ minutes.
+
+      - alert: HighSessionDuration
+        expr: |
+          histogram_quantile(0.95, rate(paws_session_duration_seconds_bucket[15m])) > 300
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: Session p95 duration above 5 minutes
+          description: The 95th percentile session duration has exceeded 5 minutes for 15+ minutes.

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -1,2 +1,2 @@
-export { createLogger } from './logger.js';
-export type { Logger, LogLevel } from './logger.js';
+export { createLogger, setGlobalLogEnricher } from './logger.js';
+export type { Logger, LogLevel, LogEnricher } from './logger.js';

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -4,6 +4,9 @@
 
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
 
+/** Pluggable enricher — called on every log emit to add dynamic fields (e.g. trace IDs). */
+export type LogEnricher = () => Record<string, unknown>;
+
 export interface Logger {
   debug(msg: string, ctx?: Record<string, unknown>): void;
   info(msg: string, ctx?: Record<string, unknown>): void;
@@ -35,22 +38,29 @@ function resolveLogLevel(): LogLevel {
  * @param baseContext - Extra fields merged into every log entry
  * @param writer - Override where output goes (default: `process.stdout.write`).
  *                 Exposed for testing — production callers should omit this.
+ * @param enricher - Called on every emit to add dynamic fields (e.g. trace IDs).
+ *                   Set via `setGlobalLogEnricher()` for trace correlation.
  */
 export function createLogger(
   component: string,
   baseContext: Record<string, unknown> = {},
   writer: (line: string) => void = (line) => process.stdout.write(line),
+  enricher?: LogEnricher,
 ): Logger {
   const minLevel = resolveLogLevel();
+  const enrich = enricher ?? globalEnricher;
 
   function emit(level: LogLevel, msg: string, ctx?: Record<string, unknown>): void {
     if (LEVEL_ORDER[level] < LEVEL_ORDER[minLevel]) return;
+
+    const traceFields = enrich ? enrich() : {};
 
     const entry = {
       ts: new Date().toISOString(),
       level,
       component,
       msg,
+      ...traceFields,
       ...baseContext,
       ...ctx,
     };
@@ -64,7 +74,21 @@ export function createLogger(
     warn: (msg, ctx) => emit('warn', msg, ctx),
     error: (msg, ctx) => emit('error', msg, ctx),
     child(extra) {
-      return createLogger(component, { ...baseContext, ...extra }, writer);
+      return createLogger(component, { ...baseContext, ...extra }, writer, enrich);
     },
   };
+}
+
+// ---------------------------------------------------------------------------
+// Global enricher — set once at startup for trace ID correlation
+// ---------------------------------------------------------------------------
+
+let globalEnricher: LogEnricher | undefined;
+
+/**
+ * Set a global log enricher that runs on every log emit.
+ * Call this once at startup after initializing tracing.
+ */
+export function setGlobalLogEnricher(enricher: LogEnricher): void {
+  globalEnricher = enricher;
 }

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@paws/telemetry",
+  "version": "0.1.0",
+  "private": true,
+  "description": "OpenTelemetry tracing and metrics for paws services",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "test": "vitest run --passWithNoTests",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@opentelemetry/api": "^1.9.1",
+    "@opentelemetry/context-async-hooks": "^2.6.1",
+    "@opentelemetry/core": "^2.6.1",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.214.0",
+    "@opentelemetry/resources": "^2.6.1",
+    "@opentelemetry/sdk-trace-base": "^2.6.1",
+    "@opentelemetry/semantic-conventions": "^1.40.0",
+    "hono": "catalog:"
+  },
+  "devDependencies": {
+    "vitest": "catalog:"
+  }
+}

--- a/packages/telemetry/src/index.ts
+++ b/packages/telemetry/src/index.ts
@@ -1,0 +1,17 @@
+export {
+  initTracing,
+  getTracer,
+  activeSpan,
+  activeTraceId,
+  activeSpanId,
+  injectTraceHeaders,
+  recordError,
+  shutdownTracing,
+} from './tracing.js';
+export type { TracingConfig } from './tracing.js';
+
+export { tracingMiddleware } from './middleware.js';
+
+// Re-export commonly used OTel API types for convenience
+export { SpanStatusCode, SpanKind } from '@opentelemetry/api';
+export type { Span } from '@opentelemetry/api';

--- a/packages/telemetry/src/middleware.ts
+++ b/packages/telemetry/src/middleware.ts
@@ -1,0 +1,67 @@
+import { context, propagation, SpanKind, SpanStatusCode, trace } from '@opentelemetry/api';
+import type { Context, MiddlewareHandler } from 'hono';
+
+import { getTracer } from './tracing.js';
+
+/**
+ * Hono middleware that creates a span for each HTTP request.
+ *
+ * Extracts incoming W3C trace context (traceparent header) so child spans
+ * link to the caller's trace. Sets standard HTTP semantic convention attributes.
+ */
+export function tracingMiddleware(serviceName?: string): MiddlewareHandler {
+  return async (c: Context, next) => {
+    const tracer = getTracer(serviceName ?? 'http');
+
+    // Extract trace context from incoming request headers
+    const carrier: Record<string, string> = {};
+    c.req.raw.headers.forEach((value, key) => {
+      carrier[key] = value;
+    });
+    const parentContext = propagation.extract(context.active(), carrier);
+
+    const method = c.req.method;
+    const url = new URL(c.req.url);
+    const route = url.pathname;
+
+    await context.with(parentContext, async () => {
+      const span = tracer.startSpan(
+        `${method} ${route}`,
+        {
+          kind: SpanKind.SERVER,
+          attributes: {
+            'http.request.method': method,
+            'url.path': route,
+            'url.scheme': url.protocol.replace(':', ''),
+            'server.port': parseInt(url.port || '0', 10) || undefined,
+            'url.query': url.search || undefined,
+          },
+        },
+        context.active(),
+      );
+
+      const spanContext = trace.setSpan(context.active(), span);
+
+      try {
+        await context.with(spanContext, () => next());
+
+        const status = c.res.status;
+        span.setAttribute('http.response.status_code', status);
+
+        if (status >= 500) {
+          span.setStatus({ code: SpanStatusCode.ERROR });
+        } else {
+          span.setStatus({ code: SpanStatusCode.OK });
+        }
+      } catch (err) {
+        span.setStatus({ code: SpanStatusCode.ERROR, message: String(err) });
+        if (err instanceof Error) {
+          span.recordException(err);
+        }
+        throw err;
+      } finally {
+        span.end();
+      }
+    });
+  };
+}

--- a/packages/telemetry/src/tracing.ts
+++ b/packages/telemetry/src/tracing.ts
@@ -1,0 +1,115 @@
+import { context, propagation, trace, type Span, SpanStatusCode } from '@opentelemetry/api';
+import { W3CTraceContextPropagator } from '@opentelemetry/core';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
+import { resourceFromAttributes } from '@opentelemetry/resources';
+import {
+  BasicTracerProvider,
+  BatchSpanProcessor,
+  SimpleSpanProcessor,
+} from '@opentelemetry/sdk-trace-base';
+import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from '@opentelemetry/semantic-conventions';
+
+export interface TracingConfig {
+  serviceName: string;
+  serviceVersion?: string;
+  /** OTLP endpoint. Defaults to OTEL_EXPORTER_OTLP_ENDPOINT or http://localhost:4318 */
+  endpoint?: string;
+  /** Use SimpleSpanProcessor (flush immediately) instead of batching. Useful for tests. */
+  sync?: boolean;
+}
+
+let provider: BasicTracerProvider | undefined;
+
+/**
+ * Initialize OpenTelemetry tracing. Call once at service startup, before creating the Hono app.
+ * Returns the provider for graceful shutdown.
+ */
+export function initTracing(config: TracingConfig): BasicTracerProvider {
+  if (provider) return provider;
+
+  const resource = resourceFromAttributes({
+    [ATTR_SERVICE_NAME]: config.serviceName,
+    [ATTR_SERVICE_VERSION]: config.serviceVersion ?? '0.1.0',
+  });
+
+  const endpoint =
+    config.endpoint ?? process.env['OTEL_EXPORTER_OTLP_ENDPOINT'] ?? 'http://localhost:4318';
+
+  const exporter = new OTLPTraceExporter({
+    url: `${endpoint}/v1/traces`,
+  });
+
+  const Processor = config.sync ? SimpleSpanProcessor : BatchSpanProcessor;
+
+  // Set up context manager before creating the provider
+  const contextManager = new AsyncLocalStorageContextManager();
+  contextManager.enable();
+  context.setGlobalContextManager(contextManager);
+
+  // W3C Trace Context propagation (traceparent/tracestate headers)
+  propagation.setGlobalPropagator(new W3CTraceContextPropagator());
+
+  provider = new BasicTracerProvider({
+    resource,
+    spanProcessors: [new Processor(exporter)],
+  });
+
+  // Register as the global tracer provider
+  trace.setGlobalTracerProvider(provider);
+
+  return provider;
+}
+
+/** Get a tracer by name (typically the package/module name). */
+export function getTracer(name: string) {
+  return trace.getTracer(name);
+}
+
+/** Get the current active span, if any. */
+export function activeSpan(): Span | undefined {
+  return trace.getActiveSpan();
+}
+
+/** Get trace ID from the current active span, or undefined. */
+export function activeTraceId(): string | undefined {
+  const span = trace.getActiveSpan();
+  if (!span) return undefined;
+  const ctx = span.spanContext();
+  // All-zero trace ID means no valid trace
+  if (ctx.traceId === '00000000000000000000000000000000') return undefined;
+  return ctx.traceId;
+}
+
+/** Get span ID from the current active span, or undefined. */
+export function activeSpanId(): string | undefined {
+  const span = trace.getActiveSpan();
+  if (!span) return undefined;
+  return span.spanContext().spanId;
+}
+
+/**
+ * Inject W3C trace context headers into an outbound request.
+ * Use this when making HTTP calls between services to propagate traces.
+ */
+export function injectTraceHeaders(headers: Record<string, string> = {}): Record<string, string> {
+  propagation.inject(context.active(), headers);
+  return headers;
+}
+
+/** Record an error on the active span. */
+export function recordError(error: Error): void {
+  const span = trace.getActiveSpan();
+  if (span) {
+    span.recordException(error);
+    span.setStatus({ code: SpanStatusCode.ERROR, message: error.message });
+  }
+}
+
+/** Gracefully shut down the tracer provider. Call on SIGTERM. */
+export async function shutdownTracing(): Promise<void> {
+  if (provider) {
+    await provider.shutdown();
+    provider = undefined;
+  }
+}

--- a/packages/telemetry/tsconfig.json
+++ b/packages/telemetry/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../packages/typescript-config/library.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": []
+  },
+  "include": ["src"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,7 @@
     { "path": "packages/proxy" },
     { "path": "packages/snapshot-store" },
     { "path": "packages/firecracker" },
+    { "path": "packages/telemetry" },
 
     { "path": "packages/sdk" },
     { "path": "providers/hetzner-cloud" },


### PR DESCRIPTION
## Summary
- **New `@paws/telemetry` package** — OpenTelemetry SDK setup for Bun (programmatic init, no `--require`), Hono tracing middleware that creates spans per request with HTTP semantic conventions, W3C trace context propagation helpers
- **Grafana Tempo** added to docker-compose — accepts OTLP traces on 4317/4318, generates span-metrics and service graphs to VictoriaMetrics
- **Control-plane + worker instrumented** — tracing middleware on all routes, cross-service trace propagation in worker-client fetch calls
- **Log-trace correlation** — logger enriched with `traceId`/`spanId` fields via pluggable enricher pattern (no hard dep on telemetry)
- **Grafana datasource wiring** — Tempo with trace-to-logs (Loki) and trace-to-metrics (VictoriaMetrics) correlation, derived fields for clickable trace links in log lines
- **Alerting rules** — VictoriaMetrics rules for: worker down, degraded workers, control plane down, high session failure rate, queue backlog, capacity exhaustion, high API latency, high session duration

## What this enables
- Trace a single request across control-plane → worker → VM execution
- Click from a log line to its trace in Grafana
- Service dependency graph auto-generated from trace data
- Alerts on SLI violations (availability, latency, capacity)

## Test plan
- [x] `bun run typecheck` — 41/41 tasks pass
- [x] `bun run test` — 30/30 tasks pass
- [ ] Deploy with `docker-compose up` and verify Tempo receives traces
- [ ] Verify Grafana Explore → Tempo shows traces from both services
- [ ] Verify log lines contain `traceId` fields and link to Tempo

🤖 Generated with [Claude Code](https://claude.com/claude-code)