### PR TITLE
fix: address unresolved review feedback from PRs #77 and #82

### DIFF
--- a/apps/control-plane/src/db/schema.ts
+++ b/apps/control-plane/src/db/schema.ts
@@ -25,6 +25,7 @@ export const daemons = sqliteTable('daemons', {
   status: text('status').notNull().default('active'),
   snapshot: text('snapshot').notNull(),
   trigger: text('trigger', { mode: 'json' }).notNull(),
+  workspace: text('workspace'),
   workload: text('workload', { mode: 'json' }),
   agent: text('agent', { mode: 'json' }),
   resources: text('resources', { mode: 'json' }),

--- a/apps/control-plane/src/store/daemons.ts
+++ b/apps/control-plane/src/store/daemons.ts
@@ -15,6 +15,7 @@ export interface StoredDaemon {
   status: DaemonStatus;
   snapshot: string;
   trigger: Trigger;
+  workspace?: string | undefined;
   workload?: Workload | undefined;
   agent?: AgentConfig | undefined;
   resources?: Resources | undefined;
@@ -51,6 +52,7 @@ export function createDaemonStore(): DaemonStore {
         status: 'active',
         snapshot: request.snapshot,
         trigger: request.trigger,
+        workspace: request.workspace,
         workload: request.workload,
         agent: request.agent,
         resources: request.resources,
@@ -126,6 +128,7 @@ function rowToStoredDaemon(row: DaemonRow): StoredDaemon {
     status: row.status as DaemonStatus,
     snapshot: row.snapshot,
     trigger: row.trigger as Trigger,
+    workspace: (row as { workspace?: string | null }).workspace ?? undefined,
     workload: (row.workload as Workload) ?? undefined,
     agent: (row.agent as AgentConfig) ?? undefined,
     resources: (row.resources as Resources) ?? undefined,
@@ -154,6 +157,7 @@ export function createSqliteDaemonStore(db: PawsDatabase): DaemonStore {
           status: 'active',
           snapshot: request.snapshot,
           trigger: request.trigger,
+          workspace: request.workspace ?? null,
           workload: request.workload ?? null,
           agent: request.agent ?? null,
           resources: request.resources ?? null,
@@ -183,6 +187,7 @@ export function createSqliteDaemonStore(db: PawsDatabase): DaemonStore {
       if (patch.status !== undefined) values['status'] = patch.status;
       if (patch.snapshot !== undefined) values['snapshot'] = patch.snapshot;
       if (patch.trigger !== undefined) values['trigger'] = patch.trigger;
+      if (patch.workspace !== undefined) values['workspace'] = patch.workspace;
       if (patch.workload !== undefined) values['workload'] = patch.workload;
       if (patch.agent !== undefined) values['agent'] = patch.agent;
       if (patch.resources !== undefined) values['resources'] = patch.resources;

--- a/packages/domains/workspace/src/types.ts
+++ b/packages/domains/workspace/src/types.ts
@@ -64,7 +64,7 @@ export const UpdateWorkspaceRequestSchema = z
     repos: z.array(WorkspaceRepoSchema).min(1).optional(),
     settings: WorkspaceSettingsSchema.optional(),
   })
-  .refine((data) => Object.keys(data).length > 0, {
+  .refine((data) => Object.values(data).some((v) => v !== undefined), {
     message: 'At least one field must be provided',
   });
 

--- a/packages/domains/workspace/tsconfig.json
+++ b/packages/domains/workspace/tsconfig.json
@@ -3,8 +3,7 @@
   "compilerOptions": {
     "composite": true,
     "outDir": "dist",
-    "rootDir": "src",
-    "types": []
+    "rootDir": "src"
   },
   "include": ["src"]
 }

--- a/packages/proxy/src/server.ts
+++ b/packages/proxy/src/server.ts
@@ -42,10 +42,15 @@ export function createProxy(config: ProxyConfig): ProxyInstance {
     const hostname = url.hostname;
 
     if (!matchesDomain(hostname, allowlist)) {
+      const durationMs = Math.round(performance.now() - startTime);
       log.warn('domain blocked', {
         domain: hostname,
         method: req.method,
         path: url.pathname,
+        statusCode: 403,
+        durationMs,
+        credentialsInjected: false,
+        protocol,
       });
       return new Response('Blocked by network policy', { status: 403 });
     }
@@ -108,6 +113,7 @@ export function createProxy(config: ProxyConfig): ProxyInstance {
           domain: hostname,
           method: req.method,
           path: url.pathname,
+          statusCode: 502,
           durationMs,
           credentialsInjected,
           protocol,
@@ -153,7 +159,7 @@ export function createProxy(config: ProxyConfig): ProxyInstance {
       log.info('proxy started', {
         host: config.listen.host,
         httpPort: actualHttpPort,
-        httpsPort: caCert ? config.listen.port + 1 : null,
+        httpsPort: caCert && caKey ? config.listen.port + 1 : null,
         allowlistedDomains: allowlist.length,
       });
     },


### PR DESCRIPTION
## Summary

Addresses 6 unresolved CodeRabbit review comments that were never fixed before merge:

### Proxy audit logging (#77)
- **Blocked-request logs missing fields** — added `statusCode: 403`, `durationMs`, `credentialsInjected: false`, `protocol` for schema consistency with forwarded-request logs
- **Upstream-failure logs missing `statusCode`** — added `statusCode: 502`
- **`httpsPort` log condition wrong** — changed `caCert ?` to `caCert && caKey ?` so log accurately reflects whether HTTPS actually started

### Workspace domain (#82)
- **`workspace` field silently dropped** — added to CP `StoredDaemon` interface, in-memory store `create()`, SQLite store `create()`/`update()`/`rowToStoredDaemon()`, and DB schema
- **`UpdateWorkspaceRequestSchema` accepts all-undefined** — changed `.refine()` from `Object.keys(data).length > 0` to `Object.values(data).some(v => v !== undefined)`
- **`tsconfig.json` has `"types": []`** — removed, violates repo convention (types from root `@types/bun`)

### Not fixed (CodeRabbit was wrong)
- `@paws/logger: "workspace:*"` — CodeRabbit suggested `catalog:` but `@paws/logger` is a workspace package, not an npm dep. `workspace:*` is correct.

## Test plan

- [x] All 31 turbo tasks pass (183 control plane tests)
- [x] Typecheck passes
- [ ] Verify daemon creation with workspace field persists in SQLite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workspace support for daemon management and storage.

* **Bug Fixes**
  * Improved validation logic for workspace update requests to ensure at least one field is provided.
  * Enhanced proxy logging with additional diagnostic information for blocked domains and connection failures.
  * Fixed HTTPS port reporting in startup logs to accurately reflect server configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->